### PR TITLE
[no ticket]: Fix javadoc code snippet.

### DIFF
--- a/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
@@ -18,9 +18,8 @@ import org.springframework.web.servlet.NoHandlerFoundException;
  * <p>Sample code:
  *
  * <pre>
- * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<T> {
- *   @Override
- *   T generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
+ * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler {
+ *  ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
  *     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);
  *   }
  * }

--- a/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
@@ -18,8 +18,10 @@ import org.springframework.web.servlet.NoHandlerFoundException;
  * <p>Sample code:
  *
  * <pre>
- * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler {
- *  ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
+ * &#64;RestControllerAdvice
+ * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler#60;ErrorReport&#62; {
+ *   &#64;Override
+ *   ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List#60;String&#62; causes) {
  *     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);
  *   }
  * }

--- a/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
@@ -19,9 +19,9 @@ import org.springframework.web.servlet.NoHandlerFoundException;
  *
  * <pre>
  * &#64;RestControllerAdvice
- * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler#60;ErrorReport&#62; {
+ * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler&#60;ErrorReport&#62; {
  *   &#64;Override
- *   ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List#60;String&#62; causes) {
+ *   ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List&#60;String&#62; causes) {
  *     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);
  *   }
  * }

--- a/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
@@ -18,9 +18,9 @@ import org.springframework.web.servlet.NoHandlerFoundException;
  * <p>Sample code:
  *
  * <pre>
- * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<?> {
+ * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<T> {
  *   @Override
- *   ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
+ *   T generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
  *     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);
  *   }
  * }

--- a/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
@@ -18,8 +18,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
  * <p>Sample code:
  *
  * <pre>
- * @RestControllerAdvice
- * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<ErrorReport> {
+ * public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<?> {
  *   @Override
  *   ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
  *     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);


### PR DESCRIPTION
For javadoc we need to cast `@`, `<` and `>`
https://reflectoring.io/howto-format-code-snippets-in-javadoc/
