### PR TITLE
[PF-375]: Encode error message in http response. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 group 'bio.terra'
-version '0.0.9-SNAPSHOT'
+version '0.0.9.1-SNAPSHOT'
 sourceCompatibility = JavaVersion.VERSION_11
 
 dependencies {

--- a/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/common/exception/AbstractGlobalExceptionHandler.java
@@ -65,5 +65,5 @@ public abstract class AbstractGlobalExceptionHandler<T> {
     return new ResponseEntity<>(generateErrorReport(ex, statusCode, causes), statusCode);
   }
 
-  abstract T generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes);
+  public abstract T generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes);
 }

--- a/src/main/java/bio/terra/common/exception/BadRequestException.java
+++ b/src/main/java/bio/terra/common/exception/BadRequestException.java
@@ -16,7 +16,7 @@ public class BadRequestException extends ErrorReportException {
   }
 
   public BadRequestException(Throwable cause) {
-    super(null, cause, null, thisStatus);
+    super(cause, thisStatus);
   }
 
   public BadRequestException(String message, List<String> causes) {

--- a/src/main/java/bio/terra/common/exception/ErrorReportException.java
+++ b/src/main/java/bio/terra/common/exception/ErrorReportException.java
@@ -32,6 +32,12 @@ public abstract class ErrorReportException extends RuntimeException {
     this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
   }
 
+  public ErrorReportException(Throwable cause, HttpStatus statusCode) {
+    super(cause);
+    this.causes = null;
+    this.statusCode = statusCode;
+  }
+
   public ErrorReportException(String message, List<String> causes, HttpStatus statusCode) {
     super(encodeMessage(message));
     this.causes = causes;

--- a/src/main/java/bio/terra/common/exception/ErrorReportException.java
+++ b/src/main/java/bio/terra/common/exception/ErrorReportException.java
@@ -1,5 +1,6 @@
 package bio.terra.common.exception;
 
+import com.google.common.html.HtmlEscapers;
 import java.util.List;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.springframework.http.HttpStatus;
@@ -14,13 +15,13 @@ public abstract class ErrorReportException extends RuntimeException {
   private final HttpStatus statusCode;
 
   public ErrorReportException(String message) {
-    super(message);
+    super(encodeMessage(message));
     this.causes = null;
     this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
   }
 
   public ErrorReportException(String message, Throwable cause) {
-    super(message, cause);
+    super(encodeMessage(message), cause);
     this.causes = null;
     this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
   }
@@ -32,14 +33,14 @@ public abstract class ErrorReportException extends RuntimeException {
   }
 
   public ErrorReportException(String message, List<String> causes, HttpStatus statusCode) {
-    super(message);
+    super(encodeMessage(message));
     this.causes = causes;
     this.statusCode = statusCode;
   }
 
   public ErrorReportException(
       String message, Throwable cause, List<String> causes, HttpStatus statusCode) {
-    super(message, cause);
+    super(encodeMessage(message), cause);
     this.causes = causes;
     this.statusCode = statusCode;
   }
@@ -58,5 +59,9 @@ public abstract class ErrorReportException extends RuntimeException {
         .append("causes", causes)
         .append("statusCode", statusCode)
         .toString();
+  }
+
+  private static String encodeMessage(String message) {
+    return HtmlEscapers.htmlEscaper().escape(message);
   }
 }

--- a/src/main/java/bio/terra/common/exception/InternalServerErrorException.java
+++ b/src/main/java/bio/terra/common/exception/InternalServerErrorException.java
@@ -16,7 +16,7 @@ public class InternalServerErrorException extends ErrorReportException {
   }
 
   public InternalServerErrorException(Throwable cause) {
-    super(null, cause, null, thisStatus);
+    super(cause, thisStatus);
   }
 
   public InternalServerErrorException(String message, List<String> causes) {

--- a/src/main/java/bio/terra/common/exception/UnauthorizedException.java
+++ b/src/main/java/bio/terra/common/exception/UnauthorizedException.java
@@ -16,7 +16,7 @@ public class UnauthorizedException extends ErrorReportException {
   }
 
   public UnauthorizedException(Throwable cause) {
-    super(null, cause, null, thisStatus);
+    super(cause, thisStatus);
   }
 
   public UnauthorizedException(String message, List<String> causes) {

--- a/src/test/java/bio/terra/common/db/DatabaseRetryUtilsTest.java
+++ b/src/test/java/bio/terra/common/db/DatabaseRetryUtilsTest.java
@@ -15,6 +15,7 @@ public class DatabaseRetryUtilsTest {
   private static final CannotSerializeTransactionException RETRY_EXCEPTION =
       new CannotSerializeTransactionException("test");
 
+  @SuppressWarnings("unchecked")
   @Mock
   DatabaseRetryUtils.DatabaseOperation<Boolean> mockDatabaseOperation =
       mock(DatabaseRetryUtils.DatabaseOperation.class);

--- a/src/test/java/bio/terra/common/exception/AbstractGlobalExceptionHandlerTest.java
+++ b/src/test/java/bio/terra/common/exception/AbstractGlobalExceptionHandlerTest.java
@@ -45,7 +45,8 @@ public class AbstractGlobalExceptionHandlerTest {
 
   private static class TestExceptionHandler extends AbstractGlobalExceptionHandler<ErrorReport> {
     @Override
-    ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List causes) {
+    public ErrorReport generateErrorReport(
+        Throwable ex, HttpStatus statusCode, List<String> causes) {
       return new ErrorReport(statusCode);
     }
   }

--- a/src/test/java/bio/terra/common/exception/ErrorReportExceptionTest.java
+++ b/src/test/java/bio/terra/common/exception/ErrorReportExceptionTest.java
@@ -1,0 +1,16 @@
+package bio.terra.common.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Test for {@link ErrorReportException} */
+@Tag("unit")
+public class ErrorReportExceptionTest {
+  @Test
+  public void encodeMessage() {
+    assertEquals("test", new UnauthorizedException("test").getMessage());
+    assertEquals("&lt;test&gt;", new UnauthorizedException("<test>").getMessage());
+  }
+}


### PR DESCRIPTION
This is one feedback from security review: 
"It would be good practice to encode the JSON objects before returning them".
This might be good for all other McTerra services, so make this part of common library. 

Also, fix few spotbug errors.