### PR TITLE
PF-281 Fix the publish workflow to start up Postgres for its unit test runs.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,11 +8,27 @@ env:
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12.3
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           ref: develop
+      - name: Initialize Postgres DB
+        env:
+          PGPASSWORD: postgres
+        run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
       - name: Set up AdoptOpenJDK 11
         uses: joschi/setup-jdk@v2
         with:


### PR DESCRIPTION
Broken in PR #11 
Maybe later we should investigate having the publish workflow use the test workflow instead of copying its test executions.