### PR TITLE
[PF-454] Remove lock clearing; fix package spelling

### DIFF
--- a/src/main/java/bio/terra/common/kubernetes/KubeService.java
+++ b/src/main/java/bio/terra/common/kubernetes/KubeService.java
@@ -10,10 +10,6 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.util.ClientBuilder;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -22,6 +18,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * KubeService provides access to a given Kubernetes environment.

--- a/src/main/java/bio/terra/common/migrate/MigrateException.java
+++ b/src/main/java/bio/terra/common/migrate/MigrateException.java
@@ -1,4 +1,4 @@
-package bio.terra.common.migirate;
+package bio.terra.common.migrate;
 
 public class MigrateException extends RuntimeException {
   public MigrateException(String message) {


### PR DESCRIPTION
The code, borrowed from TDR, would clear the liquibase lock if it were held. That was fine in TDR, since we had an outer lock that meant only one pod would be doing the migration. That will not work in general. This fix removes the lock clearing.

From the Liquibase documentation:
> Note: If Liquibase does not exit cleanly, the lock row may be left as locked. You can clear out the current lock by running liquibase releaseLocks which runs UPDATE DATABASECHANGELOGLOCK SET LOCKED=0

**NOTE**: fixing the typo in the migrate package name (from migirate) is not upward compatible.