### PR TITLE
PF-279 Don't fail on re-registration of StackdriverTraceExporter.

### DIFF
--- a/src/main/java/bio/terra/common/tracing/TracingConfig.java
+++ b/src/main/java/bio/terra/common/tracing/TracingConfig.java
@@ -112,6 +112,16 @@ public class TracingConfig implements InitializingBean, WebMvcConfigurer {
         // We do not want to prevent servers from starting up if there is an error exporting traces.
         logger.error(
             "Unable to register StackdriverTraceExporter. Traces will not be exported.", e);
+      } catch (IllegalStateException e) {
+        // In testing, the exporter may have already been registered by a previous bean setup.
+        // If the exporter is registered multiple times, an IllegalStateException is thrown.
+        // This is expected in testing.
+        // multiple times, which otherwise happens as a part of bean setup during client testing.
+        logger.warn(
+            "Unable to register StackdriverTraceExporter. In testing, this is expected "
+                + "because the exporter may have already been registered. Otherwise, traces will "
+                + "not be exported.",
+            e);
       }
     }
   }

--- a/src/main/java/bio/terra/common/tracing/TracingConfig.java
+++ b/src/main/java/bio/terra/common/tracing/TracingConfig.java
@@ -116,7 +116,6 @@ public class TracingConfig implements InitializingBean, WebMvcConfigurer {
         // In testing, the exporter may have already been registered by a previous bean setup.
         // If the exporter is registered multiple times, an IllegalStateException is thrown.
         // This is expected in testing.
-        // multiple times, which otherwise happens as a part of bean setup during client testing.
         logger.warn(
             "Unable to register StackdriverTraceExporter. In testing, this is expected "
                 + "because the exporter may have already been registered. Otherwise, traces will "


### PR DESCRIPTION
In client tests, the StackdriverTraceExporter can be registered multiple times by multiple instances TracingConfig bean. This is ok in testing.
This is hard to reproduce in terra-common-lib because we don't yet have any google credentials to allow registration to succeed, so the StackdriverTraceExporter does not get registered successfully at all, much less multiple times. I don't think it's worth adding google credentials for testing for this use case, though we may eventually want them.

Found trying to integrate with Workspace Manager.