### PR TITLE
[PF-539] Add support for logging arbitrary Gson-type JSON nodes in structured payload.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 group 'bio.terra'
-version '0.0.22-SNAPSHOT'
+version '0.0.25-SNAPSHOT'
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 def OPENCENSUS_VERSION = '0.28.+'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 group 'bio.terra'
-version '0.0.25-SNAPSHOT'
+version '0.0.22-SNAPSHOT'
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 def OPENCENSUS_VERSION = '0.28.+'

--- a/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java
+++ b/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java
@@ -133,7 +133,7 @@ class GoogleJsonLayout extends JsonLayoutBase<ILoggingEvent> {
     // All MDC properties will be directly splatted onto the JSON map. This is how the MDC
     // 'requestId' property ends up in the JSON output, and ultimately into jsonPayload.requestId
     // in cloud logging.
-    event.getMDCPropertyMap().forEach(outputMap::put);
+    outputMap.putAll(event.getMDCPropertyMap());
 
     // Generically splat any map-like or JSON-like argument to the log call onto the output JSON.
     // This is how e.g. the RequestLoggingFilter adds the 'httpRequest' object to the JSON output.
@@ -169,7 +169,7 @@ class GoogleJsonLayout extends JsonLayoutBase<ILoggingEvent> {
 
     // If the generic JSON splatting above caused a 'labels' entry to exist, move the value to
     // the well-known key that Cloud Logging will ingest as proper labels key-value pairs.
-    if (outputMap.get("labels") != null) {
+    if (outputMap.containsKey("labels")) {
       outputMap.put("logging.googleapis.com/labels", outputMap.get("labels"));
       outputMap.remove("labels");
     }

--- a/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java
+++ b/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java
@@ -60,15 +60,16 @@ import org.springframework.util.StringUtils;
  */
 class GoogleJsonLayout extends JsonLayoutBase<ILoggingEvent> {
 
-  private Tracer tracer = Tracing.getTracer();
-
   // A reference to the current Spring app context, on order to pull out the spring.application.name
   // and spring.application.version variable for inclusion in JSON output.
   private ConfigurableApplicationContext applicationContext;
+  // A Gson instance to support converting Gson-type payloads into Jackson nodes.
   private Gson gson;
+  // A Jackson ObjectMapper to support converting Gson-type payloads into Jackson nodes.
   private ObjectMapper objectMapper;
   // A Logback utility class to assist with handling stack traces.
   private ThrowableProxyConverter throwableProxyConverter;
+  private Tracer tracer = Tracing.getTracer();
 
   public GoogleJsonLayout(ConfigurableApplicationContext applicationContext) {
     super();

--- a/src/test/java/bio/terra/common/logging/LoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTest.java
@@ -162,6 +162,7 @@ public class LoggingTest {
     String event1 = null;
     String event2 = null;
     String event3 = null;
+    String event4 = null;
     for (String line : lines) {
       String message = (String) readJson(line, "$.message");
       if (message != null && message.contains("Some event happened")) {
@@ -170,6 +171,8 @@ public class LoggingTest {
         event2 = line;
       } else if (message != null && message.contains("Structured data")) {
         event3 = line;
+      } else if (message != null && message.contains("GSON object")) {
+        event4 = line;
       }
     }
 
@@ -184,6 +187,9 @@ public class LoggingTest {
     assertThat(event3).isNotNull();
     assertThat((String) readJson(event3, "$.pojo.name")).isEqualTo("asdf");
     assertThat((Integer) readJson(event3, "$.pojo.id")).isEqualTo(1234);
+
+    assertThat(event4).isNotNull();
+    assertThat((String) readJson(event4, "$.foo")).isEqualTo("bar");
   }
 
   // Uses the JsonPath library to extract data from a given path within a JSON string.

--- a/src/test/java/bio/terra/common/logging/LoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTest.java
@@ -189,7 +189,7 @@ public class LoggingTest {
     assertThat((Integer) readJson(event3, "$.pojo.id")).isEqualTo(1234);
 
     assertThat(event4).isNotNull();
-    assertThat((String) readJson(event4, "$.foo")).isEqualTo("bar");
+    assertThat((String) readJson(event4, "$.foo.bar")).isEqualTo("baz");
   }
 
   // Uses the JsonPath library to extract data from a given path within a JSON string.

--- a/src/test/java/bio/terra/common/logging/LoggingTestController.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTestController.java
@@ -1,6 +1,7 @@
 package bio.terra.common.logging;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.gson.JsonObject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,5 +41,11 @@ public class LoggingTestController {
     pojo.name = "asdf";
     pojo.id = 1234;
     LOG.info("Structured data", LoggingUtils.structuredLogData("pojo", pojo));
+
+    // Test that a raw GSON JsonObject works too. Some libraries such as CRL may prefer to include
+    // GSON type objects in the log event payload.
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("foo", "bar");
+    LOG.info("GSON object", jsonObject);
   }
 }

--- a/src/test/java/bio/terra/common/logging/LoggingTestController.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTestController.java
@@ -45,7 +45,10 @@ public class LoggingTestController {
     // Test that a raw GSON JsonObject works too. Some libraries such as CRL may prefer to include
     // GSON type objects in the log event payload.
     JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("foo", "bar");
+    JsonObject innerObject = new JsonObject();
+    innerObject.addProperty("bar", "baz");
+    jsonObject.add("foo", innerObject);
+    // The GSON should look like {"foo": {"bar": "baz"}}
     LOG.info("GSON object", jsonObject);
   }
 }

--- a/src/test/java/bio/terra/common/logging/LoggingTestController.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTestController.java
@@ -8,6 +8,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * A controller providing Spring REST API calls to exercise common logging functionality. See {@link
+ * LoggingTest} for its use and assertions.
+ */
 @RestController
 @SuppressFBWarnings(value = "UrF", justification = "Pojo fields are unread but serialized to JSON")
 public class LoggingTestController {


### PR DESCRIPTION
This is one of the precursor steps to rolling out the TCL logging package to RBS.

The overall goal is to make it so RBS produces structured logs for CRL-initiated actions, including full request payload and any Google exception data.

We should be able to use the "structured payload" approach that the TCL logging package implements, where a service can simply write

```
LOG.info("message", structuredData)
```

and the structuredData will show up as part of the `jsonPayload` in Cloud Logging.

However, one wrinkle in the implementation is that the logging library uses Jackson for JSON serialization, while CRL uses Gson. The path of least resistance here seemed to be to explicitly support a `gson.JsonObject` in the logging payload, similar to how we already support a Jackson-style `jackson.databind.JsonNode`.