### PR TITLE
[no ticket] Add docs on locally testing through mavenLocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,19 @@ psql -f local-dev/local-postgres-init.sql
 
 ### Local testing
 When working on a TCL package, it is often helpful to be able to quickly test out changes
-in the context of a service repo (e.g. terra-workspace-manager or terra-resource-buffer)
+in the context of a service repo (e.g. `terra-workspace-manager` or `terra-resource-buffer`)
 running a local server.
 
-The recommended way to iterate on local testing is by publishing TCL to a local Maven repo
-and loading the package from within the service repo:
+Gradle makes this very easy with a `mavenLocal` target for publishing and loading packages:
 
-1. Bump the TCL version number locally:
+1. Publish from TCL to your machine's local Maven cache.
    
-   `'0.0.22-SNAPSHOT' -> '0.0.23-SNAPSHOT'`
-
-2. Publish to your machine's local Maven cache:
-   
-   ```./gradlew publishToMavenLocal```
+   ```
+   ./gradlew publishToMavenLocal
+   ```
     
-3. From the service repo, add `mavenLocal()` to the _first_ repository location
-build.gradle file, and update the referenced TCL version:
+2. From the service repo, add `mavenLocal()` to the _first_ repository location
+build.gradle file (e.g. before `mavenCentral()`.
 
    ```
    # terra-workspace-manager/build.gradle
@@ -77,10 +74,7 @@ build.gradle file, and update the referenced TCL version:
      mavenCentral()
      ...
    }
-   
-   dependencies {
-     implementation group: "bio.terra", name: 'terra-common-lib', version: "0.0.23-SNAPSHOT"      
-     ...
-   }
    ```
-   
+
+That's it! Your service should pick up locally-published changes. If your changes involved bumping 
+a minor version of a TCL package, be careful to update version numbers accordingly.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The publishing procedure is:
 3. To bump major version, we need manually update `version` in [build.gradle](build.gradle) value first then create the release.
  
 ## Development 
+
 ### Dependencies
 We use [Gradle's dependency locking](https://docs.gradle.org/current/userguide/dependency_locking.html)
 to ensure that builds use the same transitive dependencies, so they're reproducible. This means that
@@ -18,8 +19,6 @@ that mention "dependency lock state" after changing a dep, you need to do this s
 ```sh
 ./gradlew dependencies --write-locks
 ```
-
-### Setup
 
 ### Database Configuration
 Terra Common Lib includes functionality using [Stairway](https://github.com/DataBiosphere/stairway).
@@ -45,9 +44,43 @@ PGPASSWORD=tclstairwaypwd psql postgresql://127.0.0.1:5432/tclstairway -U tclsta
 ```
 
 #### Option B: Local Postgres 
-##### Database Configuration
 Set up a local Postgres instance. To set up TCL's required database for unit tests, run the following command, which will create the DB's and users:
 
 ```sh
 psql -f local-dev/local-postgres-init.sql
 ```
+
+### Local testing
+When working on a TCL package, it is often helpful to be able to quickly test out changes
+in the context of a service repo (e.g. terra-workspace-manager or terra-resource-buffer)
+running a local server.
+
+The recommended way to iterate on local testing is by publishing TCL to a local Maven repo
+and loading the package from within the service repo:
+
+1. Bump the TCL version number locally:
+   
+   `'0.0.22-SNAPSHOT' -> '0.0.23-SNAPSHOT'`
+
+2. Publish to your machine's local Maven cache:
+   
+   ```./gradlew publishToMavenLocal```
+    
+3. From the service repo, add `mavenLocal()` to the _first_ repository location
+build.gradle file, and update the referenced TCL version:
+
+   ```
+   # terra-workspace-manager/build.gradle
+   
+   repositories {
+     mavenLocal()
+     mavenCentral()
+     ...
+   }
+   
+   dependencies {
+     implementation group: "bio.terra", name: 'terra-common-lib', version: "0.0.23-SNAPSHOT"      
+     ...
+   }
+   ```
+   


### PR DESCRIPTION
This makes it super easy to cross-check changes against a local service.

(We should probably add similar docs to the CRL readme too.)