### PR TITLE
[no ticket] Use broadbot-specific secret for version bumps

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -79,7 +79,7 @@ jobs:
       - name: "Bump the tag to a new version"
         uses: databiosphere/github-actions/actions/bumper@v0.0.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: develop
           VERSION_FILE_PATH: build.gradle

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: "Bump the tag to a new version"
         uses: databiosphere/github-actions/actions/bumper@v0.0.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: develop
           VERSION_FILE_PATH: build.gradle


### PR DESCRIPTION
This follows Mariko's fix from https://github.com/DataBiosphere/terra-cli/pull/34/files. We need to use the Broadbot-specific token rather than the default repo token ([ref](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret)).

This would ideally be an org-wide secret to reduce manual setup churn; see DDO-1146 tracking that cleanup.