### PR TITLE
use cluster name suffix

### DIFF
--- a/src/main/java/bio/terra/common/stairway/StairwayComponent.java
+++ b/src/main/java/bio/terra/common/stairway/StairwayComponent.java
@@ -139,6 +139,7 @@ public class StairwayComponent {
   }
 
   private String getClusterName() {
-    return String.format("%s-%s", kubeService.getNamespace(), stairwayProperties.getClusterNameSuffix());
+    return String.format(
+        "%s-%s", kubeService.getNamespace(), stairwayProperties.getClusterNameSuffix());
   }
 }

--- a/src/main/java/bio/terra/common/stairway/StairwayComponent.java
+++ b/src/main/java/bio/terra/common/stairway/StairwayComponent.java
@@ -49,7 +49,7 @@ public class StairwayComponent {
     logger.info(
         "Creating Stairway: name: [{}]  cluster name: [{}]",
         kubeService.getPodName(),
-        stairwayProperties.getClusterName());
+        getClusterName());
   }
 
   /**
@@ -67,7 +67,7 @@ public class StairwayComponent {
             .applicationContext(context) // not necessarily a Spring ApplicationContext
             .keepFlightLog(true)
             .stairwayName(kubeProperties.getPodName())
-            .stairwayClusterName(stairwayProperties.getClusterName())
+            .stairwayClusterName(getClusterName())
             .workQueueProjectId(getDefaultProjectId())
             .enableWorkQueue(kubeProperties.isInKubernetes());
     hooks.forEach(builder::stairwayHook);
@@ -136,5 +136,9 @@ public class StairwayComponent {
 
   public StairwayComponent.Status getStatus() {
     return status.get();
+  }
+
+  private String getClusterName() {
+    return String.format("%s-%s", kubeService.getNamespace(), stairwayProperties.getClusterNameSuffix());
   }
 }

--- a/src/main/java/bio/terra/common/stairway/StairwayProperties.java
+++ b/src/main/java/bio/terra/common/stairway/StairwayProperties.java
@@ -14,7 +14,7 @@ public class StairwayProperties {
   private boolean tracingEnabled;
 
   // cluster properties
-  private String clusterName;
+  private String clusterNameSuffix;
 
   public boolean isForceCleanStart() {
     return forceCleanStart;
@@ -64,11 +64,11 @@ public class StairwayProperties {
     this.tracingEnabled = tracingEnabled;
   }
 
-  public String getClusterName() {
-    return clusterName;
+  public String getClusterNameSuffix() {
+    return clusterNameSuffix;
   }
 
-  public void setClusterName(String clusterName) {
-    this.clusterName = clusterName;
+  public void setClusterNameSuffix(String clusterNameSuffix) {
+    this.clusterNameSuffix = clusterNameSuffix;
   }
 }


### PR DESCRIPTION
The cluster name must be dynamic, so restoring the logic to  base it off the namespace and a service-specific suffix.