### PR TITLE
PF-621 Make ErrorReportException's statusCode and causes never null

### DIFF
--- a/src/main/java/bio/terra/common/exception/ErrorReportException.java
+++ b/src/main/java/bio/terra/common/exception/ErrorReportException.java
@@ -3,6 +3,7 @@ package bio.terra.common.exception;
 import com.google.common.html.HtmlEscapers;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.springframework.http.HttpStatus;
@@ -39,14 +40,14 @@ public abstract class ErrorReportException extends RuntimeException {
   public ErrorReportException(Throwable cause, HttpStatus statusCode) {
     super(cause);
     this.causes = Collections.emptyList();
-    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+    this.statusCode = Optional.ofNullable(statusCode).orElse(DEFAULT_STATUS);
   }
 
   public ErrorReportException(
       String message, @Nullable List<String> causes, @Nullable HttpStatus statusCode) {
     super(encodeMessage(message));
-    this.causes = causes != null ? causes : Collections.emptyList();
-    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+    this.causes = Optional.ofNullable(causes).orElse(Collections.emptyList());
+    this.statusCode = Optional.ofNullable(statusCode).orElse(DEFAULT_STATUS);
   }
 
   public ErrorReportException(
@@ -55,8 +56,8 @@ public abstract class ErrorReportException extends RuntimeException {
       @Nullable List<String> causes,
       @Nullable HttpStatus statusCode) {
     super(encodeMessage(message), cause);
-    this.causes = causes != null ? causes : Collections.emptyList();
-    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+    this.causes = Optional.ofNullable(causes).orElse(Collections.emptyList());
+    this.statusCode = Optional.ofNullable(statusCode).orElse(DEFAULT_STATUS);
   }
 
   public List<String> getCauses() {

--- a/src/main/java/bio/terra/common/exception/ErrorReportException.java
+++ b/src/main/java/bio/terra/common/exception/ErrorReportException.java
@@ -1,7 +1,8 @@
 package bio.terra.common.exception;
 
-import com.google.common.html.HtmlEscapers;
+import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.springframework.http.HttpStatus;
 
@@ -11,44 +12,44 @@ import org.springframework.http.HttpStatus;
  * REST response.
  */
 public abstract class ErrorReportException extends RuntimeException {
+  private static final HttpStatus DEFAULT_STATUS = HttpStatus.INTERNAL_SERVER_ERROR;
+
   private final List<String> causes;
   private final HttpStatus statusCode;
 
   public ErrorReportException(String message) {
-    super(encodeMessage(message));
-    this.causes = null;
-    this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+    super(message);
+    this.causes = Collections.emptyList();
+    this.statusCode = DEFAULT_STATUS;
   }
 
   public ErrorReportException(String message, Throwable cause) {
-    super(encodeMessage(message), cause);
-    this.causes = null;
-    this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+    super(message, cause);
+    this.causes = Collections.emptyList();
+    this.statusCode = DEFAULT_STATUS;
   }
 
   public ErrorReportException(Throwable cause) {
     super(cause);
-    this.causes = null;
-    this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
-  }
-
-  public ErrorReportException(Throwable cause, HttpStatus statusCode) {
-    super(cause);
-    this.causes = null;
-    this.statusCode = statusCode;
-  }
-
-  public ErrorReportException(String message, List<String> causes, HttpStatus statusCode) {
-    super(encodeMessage(message));
-    this.causes = causes;
-    this.statusCode = statusCode;
+    this.causes = Collections.emptyList();
+    this.statusCode = DEFAULT_STATUS;
   }
 
   public ErrorReportException(
-      String message, Throwable cause, List<String> causes, HttpStatus statusCode) {
-    super(encodeMessage(message), cause);
-    this.causes = causes;
-    this.statusCode = statusCode;
+      String message, @Nullable List<String> causes, @Nullable HttpStatus statusCode) {
+    super(message);
+    this.causes = causes != null ? causes : Collections.emptyList();
+    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+  }
+
+  public ErrorReportException(
+      String message,
+      Throwable cause,
+      @Nullable List<String> causes,
+      @Nullable HttpStatus statusCode) {
+    super(message, cause);
+    this.causes = causes != null ? causes : Collections.emptyList();
+    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
   }
 
   public List<String> getCauses() {
@@ -65,9 +66,5 @@ public abstract class ErrorReportException extends RuntimeException {
         .append("causes", causes)
         .append("statusCode", statusCode)
         .toString();
-  }
-
-  private static String encodeMessage(String message) {
-    return HtmlEscapers.htmlEscaper().escape(message);
   }
 }

--- a/src/main/java/bio/terra/common/exception/ErrorReportException.java
+++ b/src/main/java/bio/terra/common/exception/ErrorReportException.java
@@ -1,5 +1,6 @@
 package bio.terra.common.exception;
 
+import com.google.common.html.HtmlEscapers;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -18,13 +19,13 @@ public abstract class ErrorReportException extends RuntimeException {
   private final HttpStatus statusCode;
 
   public ErrorReportException(String message) {
-    super(message);
+    super(encodeMessage(message));
     this.causes = Collections.emptyList();
     this.statusCode = DEFAULT_STATUS;
   }
 
   public ErrorReportException(String message, Throwable cause) {
-    super(message, cause);
+    super(encodeMessage(message), cause);
     this.causes = Collections.emptyList();
     this.statusCode = DEFAULT_STATUS;
   }
@@ -35,9 +36,15 @@ public abstract class ErrorReportException extends RuntimeException {
     this.statusCode = DEFAULT_STATUS;
   }
 
+  public ErrorReportException(Throwable cause, HttpStatus statusCode) {
+    super(cause);
+    this.causes = Collections.emptyList();
+    this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
+  }
+
   public ErrorReportException(
       String message, @Nullable List<String> causes, @Nullable HttpStatus statusCode) {
-    super(message);
+    super(encodeMessage(message));
     this.causes = causes != null ? causes : Collections.emptyList();
     this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
   }
@@ -47,7 +54,7 @@ public abstract class ErrorReportException extends RuntimeException {
       Throwable cause,
       @Nullable List<String> causes,
       @Nullable HttpStatus statusCode) {
-    super(message, cause);
+    super(encodeMessage(message), cause);
     this.causes = causes != null ? causes : Collections.emptyList();
     this.statusCode = statusCode != null ? statusCode : DEFAULT_STATUS;
   }
@@ -66,5 +73,9 @@ public abstract class ErrorReportException extends RuntimeException {
         .append("causes", causes)
         .append("statusCode", statusCode)
         .toString();
+  }
+
+  private static String encodeMessage(String message) {
+    return HtmlEscapers.htmlEscaper().escape(message);
   }
 }


### PR DESCRIPTION
While many of the ErrorReportException's constructors have default HttpStatus values, the constructors that explicitly take a  HttpStatus allow the value to be null. Change these constructors so that HttpStatus is never null.

When there's a non http-status Sam ApiException, Stairway serialization of the wrapping ErrorReportException fails because it expects a non-null statusCode. 
https://github.com/DataBiosphere/terra-workspace-manager/blob/894e24101da748254297a95fbb30cd29a24c3053/src/main/java/bio/terra/workspace/service/job/StairwayExceptionSerializer.java#L45

Do a similar change with causes so that the default value for the collection is an empty list instead of null so that clients can skip a null check.

Corresponding WM PR: https://github.com/DataBiosphere/terra-workspace-manager/pull/277