### PR TITLE
Demo protobufs for FlightMap serialization. [not for review]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,11 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.15'
+    }
+}
 plugins {
     id 'idea'
     id 'jacoco'
@@ -6,6 +14,7 @@ plugins {
 
     id 'com.diffplug.spotless' version '5.10.2'
     id 'com.github.ben-manes.versions' version '0.33.0'
+    id 'com.google.protobuf' version '0.8.15'
     id 'com.jfrog.artifactory' version '4.13.0'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'org.springframework.boot' version '2.3.1.RELEASE'
@@ -91,6 +100,7 @@ if (hasProperty('buildScan')) {
 
 apply from: "$rootDir/gradle/dependency-locking.gradle"
 apply from: "$rootDir/gradle/javadoc.gradle"
+apply from: "$rootDir/gradle/proto.gradle"
 apply from: "$rootDir/gradle/publishing.gradle"
 apply from: "$rootDir/gradle/quality.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"

--- a/gradle/proto.gradle
+++ b/gradle/proto.gradle
@@ -1,0 +1,20 @@
+protobuf {
+    // Configure the protoc executable
+    protoc {
+        // Download from repositories
+        artifact = 'com.google.protobuf:protoc:3.15.6'
+    }
+}
+
+clean {
+    delete protobuf.generatedFilesBaseDir
+}
+
+idea {
+    module {
+        // proto files and generated Java files are automatically added as
+        // source dirs.
+        // If you have additional sources, add them here:
+        sourceDirs += file("/path/to/other/sources");
+    }
+}

--- a/src/main/proto/bio/terra/common/iam/iam.proto
+++ b/src/main/proto/bio/terra/common/iam/iam.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package bio.terra.common.iam;
+option java_package = "bio.terra.common.iam.proto";
+option java_multiple_files = true;
+
+message AuthenticatedUserRequestModel {
+  optional string email = 1;
+  optional string subject_id = 2;
+  optional string token = 3;
+}
+
+// DON'T DO THIS
+// This is not the correct way to change a proto schema - you would always modify the message in
+// place, e.g. add the 'additional_field'. For illustrative purposes only, we define two schemas to
+// be compiled into the same binary to show forward/backwards compatibility.
+message AuthenticatedUserRequestModelV2 {
+  optional string email = 1;
+  optional string subject_id = 2;
+  optional string renamed_token = 3;
+
+  optional string additional_field = 4;
+}

--- a/src/test/java/bio/terra/common/iam/AuthenticatedUserRequestTest.java
+++ b/src/test/java/bio/terra/common/iam/AuthenticatedUserRequestTest.java
@@ -172,12 +172,13 @@ public class AuthenticatedUserRequestTest {
     putMessage(inMap, "v2", messageV2);
     FlightMap outMap = new FlightMap();
     outMap.fromJson(inMap.toJson());
-    // The protobuf binary encoding is not particularly human readable: https://developers.google.com/protocol-buffers/docs/encoding
+    // The protobuf binary encoding is not particularly human readable:
+    // https://developers.google.com/protocol-buffers/docs/encoding
     // ["java.util.HashMap",{"v1":"\n\u0010test@example.com\u0012\u0007Subject\u001A\u00100123.456-789AbCd","v2":"\n\u0010test@example.com\u0012\u0007Subject\u001A\u00100123.456-789AbCd\"\u0003foo"}]
     logger.info(inMap.toJson());
     // {v1=
-    //test@example.comSubject0123.456-789AbCd, v2=
-    //test@example.comSubject0123.456-789AbCd"foo}
+    // test@example.comSubject0123.456-789AbCd, v2=
+    // test@example.comSubject0123.456-789AbCd"foo}
     logger.info(outMap.toString());
 
     // Use the V2 parser to extract the V1 serialized message.

--- a/src/test/java/bio/terra/common/iam/AuthenticatedUserRequestTest.java
+++ b/src/test/java/bio/terra/common/iam/AuthenticatedUserRequestTest.java
@@ -172,6 +172,13 @@ public class AuthenticatedUserRequestTest {
     putMessage(inMap, "v2", messageV2);
     FlightMap outMap = new FlightMap();
     outMap.fromJson(inMap.toJson());
+    // The protobuf binary encoding is not particularly human readable: https://developers.google.com/protocol-buffers/docs/encoding
+    // ["java.util.HashMap",{"v1":"\n\u0010test@example.com\u0012\u0007Subject\u001A\u00100123.456-789AbCd","v2":"\n\u0010test@example.com\u0012\u0007Subject\u001A\u00100123.456-789AbCd\"\u0003foo"}]
+    logger.info(inMap.toJson());
+    // {v1=
+    //test@example.comSubject0123.456-789AbCd, v2=
+    //test@example.comSubject0123.456-789AbCd"foo}
+    logger.info(outMap.toString());
 
     // Use the V2 parser to extract the V1 serialized message.
     AuthenticatedUserRequestModelV2 message1AsV2 =


### PR DESCRIPTION
Show how we could use protobufs for serializing data to store within FlightMaps, with clearly defined schema evolution properties.
See https://developers.google.com/protocol-buffers/docs/proto3