### PR TITLE
[no ticket] Try to fix flaky log test

### DIFF
--- a/src/test/java/bio/terra/common/logging/LoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTest.java
@@ -164,7 +164,7 @@ public class LoggingTest {
     String event3 = null;
     String event4 = null;
     for (String line : lines) {
-      String message = (String) readJson(line, "$.message");
+      String message = readJson(line, "$.message");
       if (message != null && message.contains("Some event happened")) {
         event1 = line;
       } else if (message != null && message.contains("Another event")) {
@@ -194,6 +194,10 @@ public class LoggingTest {
 
   // Uses the JsonPath library to extract data from a given path within a JSON string.
   private <T> T readJson(String line, String path) {
+    if (line.isEmpty()) {
+      // JsonPath does not allow empty strings to be parsed.
+      return null;
+    }
     // Suppress exceptions, otherwise JsonPath will throw an exception when we look for a path that
     // doesn't exist. It's better to assert a null return value in that case.
     return (T)

--- a/src/test/java/bio/terra/common/logging/LoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTest.java
@@ -11,6 +11,7 @@ import com.jayway.jsonpath.Option;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Tracing;
 import java.io.IOException;
+import javax.annotation.Nullable;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -193,6 +194,7 @@ public class LoggingTest {
   }
 
   // Uses the JsonPath library to extract data from a given path within a JSON string.
+  @Nullable
   private <T> T readJson(String line, String path) {
     if (line.isEmpty()) {
       // JsonPath does not allow empty strings to be parsed.


### PR DESCRIPTION
I think we get occasional flaky test failures if we happen to log two consecutive newlines, as there's a precondition that the string passed to JsonPath is not empty, and the regex split on `\n` will return empty string on consecutive newlines.

Haven't been able to reproduce the flake locally.
`
bio.terra.common.logging.LoggingTest > testStructuredLogging(CapturedOutput) FAILED
    java.lang.IllegalArgumentException: json string can not be null or empty
        at com.jayway.jsonpath.internal.Utils.notEmpty(Utils.java:386)
        at com.jayway.jsonpath.internal.ParseContextImpl.parse(ParseContextImpl.java:36)
        at bio.terra.common.logging.LoggingTest.readJson(LoggingTest.java:201)
        at bio.terra.common.logging.LoggingTest.testStructuredLogging(LoggingTest.java:167)
        `