### PR TITLE
[PF-666] Add new Exception type for when Sam service calls or retries are interrupted.

### DIFF
--- a/src/main/java/bio/terra/common/sam/exception/SamExceptionFactory.java
+++ b/src/main/java/bio/terra/common/sam/exception/SamExceptionFactory.java
@@ -59,4 +59,9 @@ public class SamExceptionFactory {
         return new SamInternalServerErrorException(message, apiException);
     }
   }
+
+  public static ErrorReportException create(
+      String messagePrefix, InterruptedException interruptedException) {
+    return new SamInterruptedException(messagePrefix, interruptedException);
+  }
 }

--- a/src/main/java/bio/terra/common/sam/exception/SamExceptionFactory.java
+++ b/src/main/java/bio/terra/common/sam/exception/SamExceptionFactory.java
@@ -60,6 +60,11 @@ public class SamExceptionFactory {
     }
   }
 
+  /**
+   * A SamInterruptedException is thrown when an Interrupted Exception is raised while Sam is
+   * retrying. This should be used in contexts outside of Stairway. In Stairway, the
+   * InterruptedException itself should be raised.
+   */
   public static ErrorReportException create(
       String messagePrefix, InterruptedException interruptedException) {
     return new SamInterruptedException(messagePrefix, interruptedException);

--- a/src/main/java/bio/terra/common/sam/exception/SamInterruptedException.java
+++ b/src/main/java/bio/terra/common/sam/exception/SamInterruptedException.java
@@ -1,0 +1,19 @@
+package bio.terra.common.sam.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+/**
+ * This exception is thrown when an Interrupted Exception is raised while Sam is retrying. This
+ * should be used in contexts outside of Stairway. In Stairway, the InterruptedException itself
+ * should be raised.
+ */
+public class SamInterruptedException extends InternalServerErrorException {
+
+  public SamInterruptedException(String message) {
+    super(message);
+  }
+
+  public SamInterruptedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
This Exception is unchecked and should be used when Sam is called outside of a Flight.