### PR TITLE
jczerk/add workflow dispatch

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch: {}
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
   ARTIFACTORY_ACCOUNT_PATH: secret/dsp/accts/artifactory/dsdejenkins

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,7 @@ name: Publish package to Release Artifactory
 on:
   release:
     types: [created]
+  workflow_dispatch: {}
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
   ARTIFACTORY_ACCOUNT_PATH: secret/dsp/accts/artifactory/dsdejenkins

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,6 @@ name: Publish package to Release Artifactory
 on:
   release:
     types: [created]
-  workflow_dispatch: {}
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
   ARTIFACTORY_ACCOUNT_PATH: secret/dsp/accts/artifactory/dsdejenkins

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ '**' ]
+  workflow_dispatch: {}
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I would have liked to make the bump+publish trigger a little more full featured like [Workspace Manager's](https://github.com/DataBiosphere/terra-workspace-manager/blob/dev/.github/workflows/tag-publish.yml#L30), but this is really a hedge against recent flakiness in GitHub actions.