### PR TITLE
[PF-615] Modify DB retry utils behavior when max retries is exceeded

### DIFF
--- a/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
+++ b/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
@@ -21,7 +21,7 @@ public final class DatabaseRetryUtils {
    *
    * @param execute database operation to execute
    * @param retrySleep fixed retry sleep interval
-   * @param maxNumAttempts maximum retries
+   * @param maxNumAttempts maximum times this operation will be run
    * @param <T> database operation class
    * @return database operation class
    * @throws InterruptedException on thread interruption

--- a/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
+++ b/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
@@ -44,7 +44,8 @@ public final class DatabaseRetryUtils {
       ++numAttempts;
       TimeUnit.MILLISECONDS.sleep(retrySleep.toMillis());
     }
-    throw new IllegalStateException("Exceeded maximum number of retries without throwing an exception. This should never happen.");
+    throw new IllegalStateException(
+        "Exceeded maximum number of retries without throwing an exception. This should never happen.");
   }
 
   /**

--- a/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
+++ b/src/main/java/bio/terra/common/db/DatabaseRetryUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.common.db;
 
+import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -24,16 +25,18 @@ public final class DatabaseRetryUtils {
    * @param <T> database operation class
    * @return database operation class
    * @throws InterruptedException on thread interruption
+   * @throws DataAccessException throws the last DB operation error if maxNumAttempts is exceeded.
    */
   public static <T> T executeAndRetry(
       DatabaseOperation<T> execute, Duration retrySleep, int maxNumAttempts)
       throws InterruptedException {
+    Preconditions.checkArgument(maxNumAttempts > 0, "maxNumAttempts must be at least 1");
     int numAttempts = 1;
     while (numAttempts <= maxNumAttempts) {
       try {
         return execute.execute();
       } catch (DataAccessException e) {
-        if (!shouldRetryQuery(e)) {
+        if (!shouldRetryQuery(e) || (numAttempts == maxNumAttempts)) {
           throw e;
         }
         logger.info("Caught exception, retrying DB operation. Attempts so far: {}", numAttempts, e);
@@ -41,7 +44,7 @@ public final class DatabaseRetryUtils {
       ++numAttempts;
       TimeUnit.MILLISECONDS.sleep(retrySleep.toMillis());
     }
-    throw new InterruptedException("Exceeds maximum number of retries.");
+    throw new IllegalStateException("Exceeded maximum number of retries without throwing an exception. This should never happen.");
   }
 
   /**


### PR DESCRIPTION
Currently, the DB retry utils will throw an InterruptedException if the maximum number of retries for an operation is exceeded. This does not match the meaning of `InterruptedException`, so this change makes the function throw the most recent database error instead.

With this change, any call to `executeAndRetry` with a `retrySleep` duration of 0 will never throw an InterruptedException. This is useful for the short serializable transactions that several services run, as they will no longer need to surface an unnecessary checked exception.

The only existing usage of this function [is in RBS](https://github.com/DataBiosphere/terra-resource-buffer/blob/master/src/main/java/bio/terra/buffer/service/pool/PoolService.java#L115), where the exception is immediately surfaced. I can update that usage after this is merged, though it isn't strictly required because the DB exceptions are unchecked.

