### PR TITLE
[PF-976] Use refactored Stairway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url 'https://broadinstitute.jfrog.io/broadinstitute/libs-release/'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         url 'https://broadinstitute.jfrog.io/broadinstitute/libs-release/'
@@ -41,14 +42,17 @@ dependencies {
     }
     implementation platform('com.google.cloud:libraries-bom:20.2.0')
 
-    implementation group: 'bio.terra', name: 'stairway', version: '0.0.56-SNAPSHOT'
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
+    // Publish the stairway library for common lib users to minimize rollout overhead
+    // of new Stairways.
+    api group: 'bio.terra', name: 'stairway-gcp', version: '0.0.66-SNAPSHOT'
 
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.18'
     implementation group: 'ch.qos.logback.contrib', name: 'logback-json-classic', version: '0.1.5'
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
     implementation group: 'com.google.cloud', name: 'google-cloud-core'
     implementation group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.1'
     implementation group: 'com.google.apis', name: 'google-api-services-logging', version: 'v2-rev20210507-1.31.0'
+    implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
     implementation group: 'io.kubernetes', name: 'client-java', version: '10.0.0'
     implementation group: 'io.opencensus', name: 'opencensus-exporter-trace-stackdriver', version: opencensus
     // commons-dbcp2 and -lang3 versions are managed by the Spring Boot plugin

--- a/src/main/java/bio/terra/common/stairway/StairwayProperties.java
+++ b/src/main/java/bio/terra/common/stairway/StairwayProperties.java
@@ -3,7 +3,21 @@ package bio.terra.common.stairway;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** This class includes the standard database properties. */
+/**
+ * Properties for configuring a Stairway instance.
+ *
+ * <p>There are three parameters involved in configuring the Stairway work queue. There are three
+ * valid setups:
+ *
+ * <ol>
+ *   <li>If we are not running in Kubernetes, these parameters are ignored
+ *   <li>clusterNameSuffix is null. gcpPubSubTopicId, and gcpPubSubSubscriptionId are provided: the
+ *       topic and subscrition are used for the work queue.
+ *   <li>clusterNameSuffix is provided. gcpPubSubTopicId and gcpPubSubSubscriptionId are null:
+ *       topicId and subscriptionId are generated based on the clusterNameSuffix and the pubsub
+ *       topic and subscription are created or found to already exist.
+ * </ol>
+ */
 @ConfigurationProperties(prefix = "terra.common.stairway")
 public class StairwayProperties {
   private boolean forceCleanStart;
@@ -16,16 +30,20 @@ public class StairwayProperties {
   private Duration completedFlightRetention;
 
   /**
-   * clusterNameSuffix is used to generate names when creating pubsub queues. It is not needed if
-   * the topicId and subscriptionId are provided.
+   * clusterNameSuffix is used to generate names when creating pubsub queues. It must be null if the
+   * topicId and subscriptionId are provided.
    */
   private String clusterNameSuffix;
 
-  /** PubSub topic to use for stairway work queue. It must exist in the current GCP project */
+  /**
+   * PubSub topic to use for stairway work queue. It must exist in the current GCP project. It must
+   * be null if clusterNameSuffix is provided.
+   */
   private String gcpPubSubTopicId;
 
   /**
-   * PubSub subscription to use for stairway work queue. It must exist in the current GCP project
+   * PubSub subscription to use for stairway work queue. It must exist in the current GCP project.
+   * It must be null if clusterNameSuffix is provided.
    */
   private String gcpPubSubSubscriptionId;
 
@@ -105,17 +123,15 @@ public class StairwayProperties {
     return gcpPubSubTopicId;
   }
 
-  public StairwayProperties gcpPubSubTopicId(String gcpPubSubTopicId) {
+  public void setGcpPubSubTopicId(String gcpPubSubTopicId) {
     this.gcpPubSubTopicId = gcpPubSubTopicId;
-    return this;
   }
 
   public String getGcpPubSubSubscriptionId() {
     return gcpPubSubSubscriptionId;
   }
 
-  public StairwayProperties gcpPubSubSubscriptionId(String gcpPubSubSubscriptionId) {
+  public void setGcpPubSubSubscriptionId(String gcpPubSubSubscriptionId) {
     this.gcpPubSubSubscriptionId = gcpPubSubSubscriptionId;
-    return this;
   }
 }

--- a/src/main/java/bio/terra/common/stairway/StairwayProperties.java
+++ b/src/main/java/bio/terra/common/stairway/StairwayProperties.java
@@ -14,42 +14,55 @@ public class StairwayProperties {
   private boolean tracingEnabled;
   private Duration retentionCheckInterval;
   private Duration completedFlightRetention;
+
+  /**
+   * clusterNameSuffix is used to generate names when creating pubsub queues. It is not needed if
+   * the topicId and subscriptionId are provided.
+   */
   private String clusterNameSuffix;
+
+  /** PubSub topic to use for stairway work queue. It must exist in the current GCP project */
+  private String gcpPubSubTopicId;
+
+  /**
+   * PubSub subscription to use for stairway work queue. It must exist in the current GCP project
+   */
+  private String gcpPubSubSubscriptionId;
 
   public boolean isForceCleanStart() {
     return forceCleanStart;
-  }
-
-  public boolean isMigrateUpgrade() {
-    return migrateUpgrade;
-  }
-
-  public int getMaxParallelFlights() {
-    return maxParallelFlights;
-  }
-
-  public Duration getQuietDownTimeout() {
-    return quietDownTimeout;
-  }
-
-  public Duration getTerminateTimeout() {
-    return terminateTimeout;
   }
 
   public void setForceCleanStart(boolean forceCleanStart) {
     this.forceCleanStart = forceCleanStart;
   }
 
+  public boolean isMigrateUpgrade() {
+    return migrateUpgrade;
+  }
+
   public void setMigrateUpgrade(boolean migrateUpgrade) {
     this.migrateUpgrade = migrateUpgrade;
+  }
+
+  public int getMaxParallelFlights() {
+    return maxParallelFlights;
   }
 
   public void setMaxParallelFlights(int maxParallelFlights) {
     this.maxParallelFlights = maxParallelFlights;
   }
 
+  public Duration getQuietDownTimeout() {
+    return quietDownTimeout;
+  }
+
   public void setQuietDownTimeout(Duration quietDownTimeout) {
     this.quietDownTimeout = quietDownTimeout;
+  }
+
+  public Duration getTerminateTimeout() {
+    return terminateTimeout;
   }
 
   public void setTerminateTimeout(Duration terminateTimeout) {
@@ -86,5 +99,23 @@ public class StairwayProperties {
 
   public void setCompletedFlightRetention(Duration completedFlightRetention) {
     this.completedFlightRetention = completedFlightRetention;
+  }
+
+  public String getGcpPubSubTopicId() {
+    return gcpPubSubTopicId;
+  }
+
+  public StairwayProperties gcpPubSubTopicId(String gcpPubSubTopicId) {
+    this.gcpPubSubTopicId = gcpPubSubTopicId;
+    return this;
+  }
+
+  public String getGcpPubSubSubscriptionId() {
+    return gcpPubSubSubscriptionId;
+  }
+
+  public StairwayProperties gcpPubSubSubscriptionId(String gcpPubSubSubscriptionId) {
+    this.gcpPubSubSubscriptionId = gcpPubSubSubscriptionId;
+    return this;
   }
 }

--- a/src/test/java/bio/terra/common/stairway/TracingHookTest.java
+++ b/src/test/java/bio/terra/common/stairway/TracingHookTest.java
@@ -10,6 +10,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
 import bio.terra.stairway.Stairway;
+import bio.terra.stairway.StairwayBuilder;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
@@ -31,7 +32,7 @@ public class TracingHookTest {
     RecordContextStep.setRecord(contextRecord);
 
     Stairway stairway =
-        StairwayTestUtils.setupStairway(Stairway.newBuilder().stairwayHook(new TracingHook()));
+        StairwayTestUtils.setupStairway(new StairwayBuilder().stairwayHook(new TracingHook()));
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
             stairway, SpanRecordingFlight.class, new FlightMap(), Duration.ofSeconds(5));
@@ -58,7 +59,7 @@ public class TracingHookTest {
     RecordContextStep.setRecord(contextRecord);
 
     Stairway stairway =
-        StairwayTestUtils.setupStairway(Stairway.newBuilder().stairwayHook(new TracingHook()));
+        StairwayTestUtils.setupStairway(new StairwayBuilder().stairwayHook(new TracingHook()));
     FlightState flightState =
         StairwayTestUtils.blockUntilFlightCompletes(
             stairway, ErrorSpanRecordingFlight.class, new FlightMap(), Duration.ofSeconds(5));

--- a/src/test/java/bio/terra/common/stairway/test/StairwayTestUtils.java
+++ b/src/test/java/bio/terra/common/stairway/test/StairwayTestUtils.java
@@ -6,6 +6,7 @@ import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.Stairway;
+import bio.terra.stairway.StairwayBuilder;
 import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.StairwayException;
 import java.time.Duration;
@@ -16,7 +17,7 @@ import javax.sql.DataSource;
 public class StairwayTestUtils {
 
   /** Returns an initialized and started Stairway instance from the Stairway.Builder. */
-  public static Stairway setupStairway(Stairway.Builder builder) {
+  public static Stairway setupStairway(StairwayBuilder builder) {
     try {
       Stairway stairway = builder.build();
       stairway.initialize(


### PR DESCRIPTION
The refactor makes `Stairway` an interface, so the `StairwayBuilder` moves into its own class.
Also, the pubsub code is factored out of the stairway library and into stairway-gcp library.

I moved dynamic construction of the pubsub queues into TCL. The target state is for pubsub objects to be created by Terraform and passed in rather than do dynamic creation. That is tracked as [PF-558](https://broadworkbench.atlassian.net/browse/PF-558)

I tested this by integrating with WSM and running the WSM full regression tests.