### PR TITLE
[PF-1247] Add log-based alerting triggers, make LoggingUtils public

### DIFF
--- a/src/main/java/bio/terra/common/logging/LoggingUtils.java
+++ b/src/main/java/bio/terra/common/logging/LoggingUtils.java
@@ -27,6 +27,25 @@ public final class LoggingUtils {
 
   private LoggingUtils() {}
 
+  // A simple string which can be included as a key in JSON logging output. This is intended to
+  // trigger log-based alerting to notify developers of unexpected errors.
+  public static final String ALERT_KEY = "terraLogBasedAlert";
+
+  public static Map<String, Boolean> alertObject() {
+    return Collections.singletonMap(ALERT_KEY, true);
+  }
+
+  /**
+   * Wrapper around logger.error() which also includes the alertObject defined above.
+   *
+   * <p>This allows callers to log at ERROR level and also trigger any environment-appropriate
+   * logging set up wherever their code is running. For logs which also need to include objects,
+   * callers can just include the alertObject() as an additional structured object to log.
+   */
+  public static void logAlert(Logger logger, String message) {
+    logger.error(message, alertObject());
+  }
+
   /**
    * Parses a JSON string and returns a Jackson JsonNode object which can be passed as an argument
    * for inclusion in JSON logging output.
@@ -43,7 +62,7 @@ public final class LoggingUtils {
    *   jsonPayload.eventType = "very-rare-event"
    * </pre>
    */
-  static JsonNode jsonFromString(String s) throws JsonProcessingException {
+  public static JsonNode jsonFromString(String s) throws JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     // Let's not be monsters here. Allow some more lenient Javascript-style JSON.
     mapper.configure(Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
@@ -67,7 +86,7 @@ public final class LoggingUtils {
    *   jsonPayload.event.subfield.value = "12345"
    * </pre>
    */
-  static Map<String, Object> structuredLogData(String key, Object value) {
+  public static Map<String, Object> structuredLogData(String key, Object value) {
     return Collections.singletonMap(key, value);
   }
 

--- a/src/test/java/bio/terra/common/logging/LoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTest.java
@@ -6,12 +6,14 @@ import static org.mockito.Mockito.when;
 import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
 
 import bio.terra.common.logging.LoggingTest.FilterTestConfiguration;
+import bio.terra.common.logging.LoggingTestController.StructuredDataPojo;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Tracing;
 import java.io.IOException;
+import java.util.Arrays;
 import javax.annotation.Nullable;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -167,23 +169,10 @@ public class LoggingTest {
     assertThat(response.getStatusCode().value()).isEqualTo(200);
 
     String[] lines = capturedOutput.getAll().split("\n");
-
-    String event1 = null;
-    String event2 = null;
-    String event3 = null;
-    String event4 = null;
-    for (String line : lines) {
-      String message = readJson(line, "$.message");
-      if (message != null && message.contains("Some event happened")) {
-        event1 = line;
-      } else if (message != null && message.contains("Another event")) {
-        event2 = line;
-      } else if (message != null && message.contains("Structured data")) {
-        event3 = line;
-      } else if (message != null && message.contains("GSON object")) {
-        event4 = line;
-      }
-    }
+    String event1 = getLogContainingMessage(lines, "Some event happened");
+    String event2 = getLogContainingMessage(lines, "Another event");
+    String event3 = getLogContainingMessage(lines, "Structured data");
+    String event4 = getLogContainingMessage(lines, "GSON object");
 
     // The first log statement included a single key-value pair. Ensure that data is included in
     // the log output.
@@ -194,8 +183,10 @@ public class LoggingTest {
     assertThat((Integer) readJson(event2, "$.b")).isEqualTo(2);
 
     assertThat(event3).isNotNull();
-    assertThat((String) readJson(event3, "$.pojo.name")).isEqualTo("asdf");
-    assertThat((Integer) readJson(event3, "$.pojo.id")).isEqualTo(1234);
+    StructuredDataPojo pojo = readJson(event3, "$.pojo", StructuredDataPojo.class);
+    assertThat(pojo).isNotNull();
+    assertThat(pojo.name).isEqualTo("asdf");
+    assertThat(pojo.id).isEqualTo(1234);
 
     assertThat(event4).isNotNull();
     assertThat((String) readJson(event4, "$.foo.bar")).isEqualTo("baz");
@@ -206,46 +197,78 @@ public class LoggingTest {
     ResponseEntity<String> response =
         testRestTemplate.getForEntity("/testAlertLogging", String.class);
     assertThat(response.getStatusCode().value()).isEqualTo(200);
+    String[] lines = capturedOutput.getAll().split("\n");
+    String logLine = getLogContainingMessage(lines, "test alert message");
+    assertThat(logLine).isNotNull();
+    assertThat((String) readJson(logLine, "$.severity")).isEqualTo("ERROR");
+    assertTrue((Boolean) readJson(logLine, "$." + LoggingUtils.ALERT_KEY));
+  }
+
+  @Test
+  public void testAlertLoggingWithObject(CapturedOutput capturedOutput) {
+    ResponseEntity<String> response =
+        testRestTemplate.getForEntity("/testAlertLoggingWithObject", String.class);
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
 
     String[] lines = capturedOutput.getAll().split("\n");
-    String event1 = null;
-    String event2 = null;
-    for (String line : lines) {
-      String message = readJson(line, "$.message");
-      if (message != null && message.contains("test alert message")) {
-        event1 = line;
-      } else if (message != null && message.contains("test structured object alert message")) {
-        event2 = line;
-      }
-    }
+    String logLine = getLogContainingMessage(lines, "test structured object alert message");
+    StructuredDataPojo pojo = readJson(logLine, "$.pojo", StructuredDataPojo.class);
+    assertThat(pojo).isNotNull();
 
-    assertThat(event1).isNotNull();
-    assertThat((String) readJson(event1, "$.severity")).isEqualTo("ERROR");
-    assertTrue((Boolean) readJson(event1, "$." + LoggingUtils.ALERT_KEY));
-    assertThat(event2).isNotNull();
-    assertThat((String) readJson(event2, "$.severity")).isEqualTo("ERROR");
-    assertThat((String) readJson(event2, "$.pojo.name")).isEqualTo("asdf");
-    assertThat((Integer) readJson(event2, "$.pojo.id")).isEqualTo(1234);
-    assertTrue((Boolean) readJson(event2, "$." + LoggingUtils.ALERT_KEY));
+    assertThat(logLine).isNotNull();
+    assertThat((String) readJson(logLine, "$.severity")).isEqualTo("ERROR");
+    assertTrue((Boolean) readJson(logLine, "$." + LoggingUtils.ALERT_KEY));
+    assertThat(pojo.name).isEqualTo("asdf");
+    assertThat(pojo.id).isEqualTo(1234);
   }
 
   // Uses the JsonPath library to extract data from a given path within a JSON string.
   @Nullable
   private <T> T readJson(String line, String path) {
+    return readJson(line, path, null);
+  }
+
+  /**
+   * Uses the JsonPath library to extract data from a given path within a JSON string.
+   *
+   * @param line The line of text to extract from
+   * @param path The JSON object path to read
+   * @param clazz Class to return. If null, this is inferred by the JsonPath library.
+   * @return
+   */
+  @Nullable
+  private <T> T readJson(String line, String path, @Nullable Class<T> clazz) {
     if (line.isEmpty()) {
       // JsonPath does not allow empty strings to be parsed.
       return null;
     }
     // Suppress exceptions, otherwise JsonPath will throw an exception when we look for a path that
     // doesn't exist. It's better to assert a null return value in that case.
-    return (T)
-        JsonPath.using(Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS))
-            .parse(line)
-            .read(path);
+    if (clazz != null) {
+      return (T)
+          JsonPath.using(
+                  Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS))
+              .parse(line)
+              .read(path, clazz);
+    } else {
+      return (T)
+          JsonPath.using(
+                  Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS))
+              .parse(line)
+              .read(path);
+    }
   }
 
   private String lastLoggedLine(CapturedOutput capturedOutput) {
     String[] lines = capturedOutput.getAll().split("\n");
     return lines[lines.length - 1];
+  }
+
+  /** Find and return the entire log line containing the provided message. */
+  private String getLogContainingMessage(String[] logLines, String message) {
+    return Arrays.stream(logLines)
+        .filter(line -> line.contains(message))
+        .findFirst()
+        .orElseThrow(() -> new RuntimeException("No log line with message " + message));
   }
 }

--- a/src/test/java/bio/terra/common/logging/LoggingTestController.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTestController.java
@@ -60,6 +60,10 @@ public class LoggingTestController {
   public void testAlertLogging() throws JsonProcessingException {
     // Test logging a message which should trigger an alert
     LoggingUtils.logAlert(LOG, "test alert message");
+  }
+
+  @GetMapping("/testAlertLoggingWithObject")
+  public void testAlertLoggingWithObject() throws JsonProcessingException {
     // Test logging both a message and object
     StructuredDataPojo pojo = new StructuredDataPojo();
     pojo.name = "asdf";

--- a/src/test/java/bio/terra/common/logging/LoggingTestController.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTestController.java
@@ -55,4 +55,18 @@ public class LoggingTestController {
     // The GSON should look like {"foo": {"bar": "baz"}}
     LOG.info("GSON object", jsonObject);
   }
+
+  @GetMapping("/testAlertLogging")
+  public void testAlertLogging() throws JsonProcessingException {
+    // Test logging a message which should trigger an alert
+    LoggingUtils.logAlert(LOG, "test alert message");
+    // Test logging both a message and object
+    StructuredDataPojo pojo = new StructuredDataPojo();
+    pojo.name = "asdf";
+    pojo.id = 1234;
+    LOG.error(
+        "test structured object alert message",
+        LoggingUtils.structuredLogData("pojo", pojo),
+        LoggingUtils.alertObject());
+  }
 }


### PR DESCRIPTION
This change adds a new utility method in LoggingUtils to log a message at `ERROR` severity with the additional key-value pair `terraLogBasedAlert: true`. We can set up log-based alerts for this key, and callers from any service can then trigger environment-appropriate alerts from log entries as needed.

This also exposes the `jsonFromString` and `structuredLogData` utils as public. It looks like these were intended to be available to library users, but they're currently package-private.