### PR TITLE
[PF-1601] Use latest bumper version in TCL

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -88,7 +88,7 @@ jobs:
           name: Test Reports
           path: build/reports
       - name: "Bump the tag to a new version"
-        uses: databiosphere/github-actions/actions/bumper@v0.0.3
+        uses: databiosphere/github-actions/actions/bumper@v0.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           DEFAULT_BUMP: patch


### PR DESCRIPTION
Looks like the previous commit failed to publish due to an old version of `bumper`: https://github.com/DataBiosphere/terra-common-lib/actions/runs/2191187628