### PR TITLE
[PF-548] Add okhttp support and move to b3 format trace headers

### DIFF
--- a/src/main/java/bio/terra/common/stairway/TracingHook.java
+++ b/src/main/java/bio/terra/common/stairway/TracingHook.java
@@ -102,10 +102,10 @@ public class TracingHook implements StairwayHook {
       // at the end of the Flight's current run.
       flightScope =
           tracer
-              .spanBuilderWithExplicitParent(
+              .spanBuilderWithRemoteParent(
                   FLIGHT_NAME_PREFIX
                       + ClassUtils.getShortClassName(flightContext.getFlightClassName()),
-                  null)
+                  submissionContext)
               .startScopedSpan();
       Span flightSpan = tracer.getCurrentSpan();
       flightSpan.addLink(Link.fromSpanContext(submissionContext, Link.Type.PARENT_LINKED_SPAN));

--- a/src/main/java/bio/terra/common/tracing/OkHttpClientTracingInterceptor.java
+++ b/src/main/java/bio/terra/common/tracing/OkHttpClientTracingInterceptor.java
@@ -10,11 +10,18 @@ import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
+/**
+ * An interceptor to add tracing headers to outgoing requests.
+ *
+ * OkHttp interceptors are called before and after network requests, and can modify the request and
+ * response objects. In this case, we're adding headers for the current traceId and span, which the
+ * remote service can read to link traces across services.
+ */
 public class OkHttpClientTracingInterceptor implements Interceptor {
-  private Tracer tracer;
+  private final Tracer tracer;
   // This looks a little odd, but OkHttp requests are immutable so the carrier type must be a
   // request builder, not a Request.
-  private HttpClientHandler<Request, Response, Request.Builder> handler;
+  private final HttpClientHandler<Request, Response, Request.Builder> handler;
   private static final Setter<Request.Builder> SETTER =
       new Setter<Request.Builder>() {
         @Override

--- a/src/main/java/bio/terra/common/tracing/OkHttpClientTracingInterceptor.java
+++ b/src/main/java/bio/terra/common/tracing/OkHttpClientTracingInterceptor.java
@@ -13,9 +13,9 @@ import okhttp3.Response;
 /**
  * An interceptor to add tracing headers to outgoing requests.
  *
- * OkHttp interceptors are called before and after network requests, and can modify the request and
- * response objects. In this case, we're adding headers for the current traceId and span, which the
- * remote service can read to link traces across services.
+ * <p>OkHttp interceptors are called before and after network requests, and can modify the request
+ * and response objects. In this case, we're adding headers for the current traceId and span, which
+ * the remote service can read to link traces across services.
  */
 public class OkHttpClientTracingInterceptor implements Interceptor {
   private final Tracer tracer;

--- a/src/main/java/bio/terra/common/tracing/OkHttpClientTracingInterceptor.java
+++ b/src/main/java/bio/terra/common/tracing/OkHttpClientTracingInterceptor.java
@@ -1,0 +1,56 @@
+package bio.terra.common.tracing;
+
+import io.opencensus.contrib.http.HttpClientHandler;
+import io.opencensus.contrib.http.HttpRequestContext;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.propagation.TextFormat.Setter;
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class OkHttpClientTracingInterceptor implements Interceptor {
+  private Tracer tracer;
+  // This looks a little odd, but OkHttp requests are immutable so the carrier type must be a
+  // request builder, not a Request.
+  private HttpClientHandler<Request, Response, Request.Builder> handler;
+  private static final Setter<Request.Builder> SETTER =
+      new Setter<Request.Builder>() {
+        @Override
+        public void put(Request.Builder carrier, String key, String value) {
+          carrier.header(key, value);
+        }
+      };
+
+  public OkHttpClientTracingInterceptor(Tracer tracer) {
+    this.tracer = tracer;
+    this.handler =
+        new HttpClientHandler<>(
+            tracer,
+            new OkHttpTracingExtractor(),
+            Tracing.getPropagationComponent().getB3Format(),
+            SETTER);
+  }
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    Request originalRequest = chain.request();
+    Request.Builder newRequestBuilder = originalRequest.newBuilder();
+
+    HttpRequestContext requestContext =
+        handler.handleStart(tracer.getCurrentSpan(), newRequestBuilder, originalRequest);
+    Request newRequest = newRequestBuilder.build();
+    Response response = null;
+    try {
+      response = chain.proceed(newRequest);
+    } catch (IOException e) {
+      // Error during call
+      handler.handleEnd(requestContext, newRequest, null, e);
+      throw e;
+    }
+    // Call succeeded
+    handler.handleEnd(requestContext, newRequest, response, null);
+    return response;
+  }
+}

--- a/src/main/java/bio/terra/common/tracing/OkHttpTracingExtractor.java
+++ b/src/main/java/bio/terra/common/tracing/OkHttpTracingExtractor.java
@@ -5,6 +5,13 @@ import javax.annotation.Nullable;
 import okhttp3.Request;
 import okhttp3.Response;
 
+/**
+ * Extractor to populate span fields from a Request object
+ *
+ * OpenCensus spans have a number of fields defined, this class extracts values from OkHttp
+ * request/response objects to populate those fields. Per the OpenCensus spec, "All attributes are
+ * optional, but collector should make the best effort to collect those."
+ */
 public class OkHttpTracingExtractor extends HttpExtractor<Request, Response> {
 
   @Nullable
@@ -12,8 +19,8 @@ public class OkHttpTracingExtractor extends HttpExtractor<Request, Response> {
   public String getRoute(Request request) {
     // OpenCensus spec wants this to be something like the literal string
     // "/api/workspace/{workspaceId}", whereas path would be "/api/workspace/12345".
-    // We don't have the route available and this is a best-effort method, so use path instead.
-    return request.url().encodedPath();
+    // We don't have the route available and this is an optional method, so return null.
+    return null;
   }
 
   @Nullable
@@ -48,6 +55,7 @@ public class OkHttpTracingExtractor extends HttpExtractor<Request, Response> {
 
   @Override
   public int getStatusCode(@Nullable Response response) {
+    // Per base class, "If the response is null, this method should return 0".
     return response != null ? response.code() : 0;
   }
 }

--- a/src/main/java/bio/terra/common/tracing/OkHttpTracingExtractor.java
+++ b/src/main/java/bio/terra/common/tracing/OkHttpTracingExtractor.java
@@ -8,7 +8,7 @@ import okhttp3.Response;
 /**
  * Extractor to populate span fields from a Request object
  *
- * OpenCensus spans have a number of fields defined, this class extracts values from OkHttp
+ * <p>OpenCensus spans have a number of fields defined, this class extracts values from OkHttp
  * request/response objects to populate those fields. Per the OpenCensus spec, "All attributes are
  * optional, but collector should make the best effort to collect those."
  */

--- a/src/main/java/bio/terra/common/tracing/OkHttpTracingExtractor.java
+++ b/src/main/java/bio/terra/common/tracing/OkHttpTracingExtractor.java
@@ -1,0 +1,53 @@
+package bio.terra.common.tracing;
+
+import io.opencensus.contrib.http.HttpExtractor;
+import javax.annotation.Nullable;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class OkHttpTracingExtractor extends HttpExtractor<Request, Response> {
+
+  @Nullable
+  @Override
+  public String getRoute(Request request) {
+    // OpenCensus spec wants this to be something like the literal string
+    // "/api/workspace/{workspaceId}", whereas path would be "/api/workspace/12345".
+    // We don't have the route available and this is a best-effort method, so use path instead.
+    return request.url().encodedPath();
+  }
+
+  @Nullable
+  @Override
+  public String getUrl(Request request) {
+    return request.url().toString();
+  }
+
+  @Nullable
+  @Override
+  public String getHost(Request request) {
+    return request.url().host();
+  }
+
+  @Nullable
+  @Override
+  public String getMethod(Request request) {
+    return request.method();
+  }
+
+  @Nullable
+  @Override
+  public String getPath(Request request) {
+    return request.url().encodedPath();
+  }
+
+  @Nullable
+  @Override
+  public String getUserAgent(Request request) {
+    return request.header("user-agent");
+  }
+
+  @Override
+  public int getStatusCode(@Nullable Response response) {
+    return response != null ? response.code() : 0;
+  }
+}


### PR DESCRIPTION
This has a couple changes to support better (and cross-service!) tracing in GCP:

- Move the common-lib tracing code to read B3 headers from incoming requests instead of the default traceContext format. Sam only supports B3 headers, so we should prefer using that everywhere instead of mixing formats across services.
- Fix the stairway tracing hook to properly track span parents
- Add an interceptor for OkHttp-based client libraries. TCL users can add this interceptor to an okHttp client library (like the Sam Java client) to propagate traces across services.