### PR TITLE
Fix GHA secret masking

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -48,8 +48,8 @@ jobs:
             vault write -field token \
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
-          echo ::set-output name=vault-token::$VAULT_TOKEN
           echo ::add-mask::$VAULT_TOKEN
+          echo ::set-output name=vault-token::$VAULT_TOKEN
       - name: Get artifactory credentials from Vault
         id: vault-secret-step
         run: |
@@ -63,10 +63,10 @@ jobs:
             -e "VAULT_ADDR=${VAULT_ADDR}" \
             vault:1.1.0 \
             vault read -field password ${ARTIFACTORY_ACCOUNT_PATH})
-          echo ::set-output name=artifactory-username::$ARTIFACTORY_USERNAME
           echo ::add-mask::$ARTIFACTORY_USERNAME
-          echo ::set-output name=artifactory-password::$ARTIFACTORY_PASSWORD
+          echo ::set-output name=artifactory-username::$ARTIFACTORY_USERNAME
           echo ::add-mask::$ARTIFACTORY_PASSWORD
+          echo ::set-output name=artifactory-password::$ARTIFACTORY_PASSWORD
       # See https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - name: Cache Gradle packages
         uses: actions/cache@v2


### PR DESCRIPTION
(Same situation as https://github.com/DataBiosphere/terra-resource-buffer/pull/244)
These workflows are masking secrets incorrectly, the masking needs to happen before setting them as output. If this workflow is run with debug logging (which it isn't), the current pattern will leak secrets.