### PR TITLE
[WOR-441] Upgrade jfrog plugin to hopefully work with newer version of Gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
     id 'com.diffplug.spotless' version '5.12.4'
     id 'com.github.ben-manes.versions' version '0.36.0'
-    id 'com.jfrog.artifactory' version '4.13.0'
+    id 'com.jfrog.artifactory' version '4.28.1'
     // [dd 2021-05-17] Use of Spring dependency management generates invalid POM, making
     // it impossible to publish to mavenLocal. In order to make TCL testable, I have
     // removed this plugin and filled in specific version numbers. I also removed all


### PR DESCRIPTION
The deployment to jfrog is failing after my last PR, which upgraded Gradle to a version that also works with JDK 17.

https://github.com/DataBiosphere/terra-common-lib/pull/78

Hopefully this will fix the issue (though I cannot find anything that lists the compatibility between jfrog and Gradle versions). FWIW, this version of jfrog is what [Workspace Manager](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/build.gradle#L3) is using with Gradle 7.4.1.