### PR TITLE
[PF-1731] Replace Java setup action

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -33,9 +33,10 @@ jobs:
           PGPASSWORD: postgres
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Pull Vault image
         run: docker pull vault:1.1.0
       # Currently, there's no way to add capabilities to Docker actions on Git, and Vault needs IPC_LOCK to run.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,10 @@ jobs:
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
       - uses: actions/checkout@v2
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       # See https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - name: Cache Gradle packages
         uses: actions/cache@v2


### PR DESCRIPTION
The `joschi/setup-jdk` Github action is deprecated and the recommendation is to move to the official github setup-java action with the `temurin` distribution: see https://github.com/joschi/setup-jdk#-notice