### PR TITLE
[PF-1959] Add DataSourceManager; refactor DataSourceInitializer

### DIFF
--- a/src/main/java/bio/terra/common/db/DataSourceInitializer.java
+++ b/src/main/java/bio/terra/common/db/DataSourceInitializer.java
@@ -10,8 +10,8 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 /**
  * Utility class to create {@link DataSource}.
  *
- * Prefer using {@DataSourceManager} instead of this code so that connection pools are
- * closed when the Spring application context is deleted.
+ * <p>Prefer using {@DataSourceManager} instead of this code so that connection pools are closed
+ * when the Spring application context is deleted.
  */
 public class DataSourceInitializer {
   private DataSourceInitializer() {}
@@ -24,13 +24,14 @@ public class DataSourceInitializer {
   }
 
   /**
-   * This method is shared by this class and the DataSourceManager so we only have one implementation
-   * of creating the connection pool
+   * This method is shared by this class and the DataSourceManager so we only have one
+   * implementation of creating the connection pool
    *
    * @param baseDatabaseProperties common database properties
    * @return connection pool
    */
-  public static ObjectPool<PoolableConnection> makeConnectionPool(BaseDatabaseProperties baseDatabaseProperties) {
+  public static ObjectPool<PoolableConnection> makeConnectionPool(
+      BaseDatabaseProperties baseDatabaseProperties) {
     Properties props = new Properties();
     props.setProperty("user", baseDatabaseProperties.getUsername());
     props.setProperty("password", baseDatabaseProperties.getPassword());

--- a/src/main/java/bio/terra/common/db/DataSourceInitializer.java
+++ b/src/main/java/bio/terra/common/db/DataSourceInitializer.java
@@ -7,13 +7,30 @@ import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
-/** Utility class to create {@link DataSource}. */
+/**
+ * Utility class to create {@link DataSource}.
+ *
+ * Prefer using {@DataSourceManager} instead of this code so that connection pools are
+ * closed when the Spring application context is deleted.
+ */
 public class DataSourceInitializer {
   private DataSourceInitializer() {}
   ;
 
   /** Create a {@link DataSource} by providing a {@link BaseDatabaseProperties}. */
   public static DataSource initializeDataSource(BaseDatabaseProperties baseDatabaseProperties) {
+    ObjectPool<PoolableConnection> connectionPool = makeConnectionPool(baseDatabaseProperties);
+    return new PoolingDataSource<>(connectionPool);
+  }
+
+  /**
+   * This method is shared by this class and the DataSourceManager so we only have one implementation
+   * of creating the connection pool
+   *
+   * @param baseDatabaseProperties common database properties
+   * @return connection pool
+   */
+  public static ObjectPool<PoolableConnection> makeConnectionPool(BaseDatabaseProperties baseDatabaseProperties) {
     Properties props = new Properties();
     props.setProperty("user", baseDatabaseProperties.getUsername());
     props.setProperty("password", baseDatabaseProperties.getPassword());
@@ -32,7 +49,6 @@ public class DataSourceInitializer {
         new GenericObjectPool<>(poolableConnectionFactory, config);
 
     poolableConnectionFactory.setPool(connectionPool);
-
-    return new PoolingDataSource<>(connectionPool);
+    return connectionPool;
   }
 }

--- a/src/main/java/bio/terra/common/db/DataSourceManager.java
+++ b/src/main/java/bio/terra/common/db/DataSourceManager.java
@@ -1,51 +1,44 @@
 package bio.terra.common.db;
 
-import org.apache.commons.dbcp2.ConnectionFactory;
-import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PreDestroy;
+import javax.sql.DataSource;
 import org.apache.commons.dbcp2.PoolableConnection;
-import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.commons.pool2.ObjectPool;
-import org.apache.commons.pool2.impl.GenericObjectPool;
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PreDestroy;
-import javax.sql.DataSource;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-
 /**
  * This class initializes data source pools just like {@link DataSourceInitializer}, but it
- * remembers the pools that it creates. It uses a @PreDestroy method to close the pools
- * when the Spring application context is closed.
+ * remembers the pools that it creates. It uses a @PreDestroy method to close the pools when the
+ * Spring application context is closed.
  *
- * Using this class is important when running JUnit tests that use @DirtiesContext directives. Without
- * this extra step, when each dirty context is deleted, connections in its pools are orphaned. Use of
- * the class has no effect in non-test environments.
+ * <p>Using this class is important when running JUnit tests that use @DirtiesContext directives.
+ * Without this extra step, when each dirty context is deleted, connections in its pools are
+ * orphaned. Use of the class has no effect in non-test environments.
  */
 @Component
 public class DataSourceManager {
-    private static final Logger logger = LoggerFactory.getLogger(DataSourceManager.class);
-    private List<ObjectPool<PoolableConnection>> connectionPools = new ArrayList<>();
+  private static final Logger logger = LoggerFactory.getLogger(DataSourceManager.class);
+  private List<ObjectPool<PoolableConnection>> connectionPools = new ArrayList<>();
 
-    @PreDestroy
-    public void destroy() {
-        logger.info("Closing all connection pools");
-        for (var pool : connectionPools) {
-            logger.info("Pool active {} idle {}", pool.getNumActive(), pool.getNumIdle());
-            pool.close();
-        }
-        connectionPools = new ArrayList<>();
+  @PreDestroy
+  public void destroy() {
+    logger.info("Closing all connection pools");
+    for (var pool : connectionPools) {
+      logger.info("Pool active {} idle {}", pool.getNumActive(), pool.getNumIdle());
+      pool.close();
     }
+    connectionPools = new ArrayList<>();
+  }
 
-    public DataSource initializeDataSource(BaseDatabaseProperties baseDatabaseProperties) {
-        ObjectPool<PoolableConnection> connectionPool = DataSourceInitializer.makeConnectionPool(baseDatabaseProperties);
-        connectionPools.add(connectionPool);
-        return new PoolingDataSource<>(connectionPool);
-    }
+  public DataSource initializeDataSource(BaseDatabaseProperties baseDatabaseProperties) {
+    ObjectPool<PoolableConnection> connectionPool =
+        DataSourceInitializer.makeConnectionPool(baseDatabaseProperties);
+    connectionPools.add(connectionPool);
+    return new PoolingDataSource<>(connectionPool);
+  }
 }
-

--- a/src/main/java/bio/terra/common/db/DataSourceManager.java
+++ b/src/main/java/bio/terra/common/db/DataSourceManager.java
@@ -1,0 +1,51 @@
+package bio.terra.common.db;
+
+import org.apache.commons.dbcp2.ConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.PoolableConnection;
+import org.apache.commons.dbcp2.PoolableConnectionFactory;
+import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PreDestroy;
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * This class initializes data source pools just like {@link DataSourceInitializer}, but it
+ * remembers the pools that it creates. It uses a @PreDestroy method to close the pools
+ * when the Spring application context is closed.
+ *
+ * Using this class is important when running JUnit tests that use @DirtiesContext directives. Without
+ * this extra step, when each dirty context is deleted, connections in its pools are orphaned. Use of
+ * the class has no effect in non-test environments.
+ */
+@Component
+public class DataSourceManager {
+    private static final Logger logger = LoggerFactory.getLogger(DataSourceManager.class);
+    private List<ObjectPool<PoolableConnection>> connectionPools = new ArrayList<>();
+
+    @PreDestroy
+    public void destroy() {
+        logger.info("Closing all connection pools");
+        for (var pool : connectionPools) {
+            logger.info("Pool active {} idle {}", pool.getNumActive(), pool.getNumIdle());
+            pool.close();
+        }
+        connectionPools = new ArrayList<>();
+    }
+
+    public DataSource initializeDataSource(BaseDatabaseProperties baseDatabaseProperties) {
+        ObjectPool<PoolableConnection> connectionPool = DataSourceInitializer.makeConnectionPool(baseDatabaseProperties);
+        connectionPools.add(connectionPool);
+        return new PoolingDataSource<>(connectionPool);
+    }
+}
+


### PR DESCRIPTION
`DataSourceInitializer` provides a static method that creates a connection pooled data source with settings taken from the database settings. It has a very specific problem: if you are running JUnit tests and you use the `@DirtiesContext` annotation, then Spring will destroy the associated application context. In the process, it abandons the connection pools without closing the connections. In the WSM case that turned up this problem, we ran out of database connections.

The new `DataSourceManager` is a `@Component` that does the same thing as `DataSourceInitializer` (I set it up to share the pool construction code) but the Manager remembers the pools that it has created. It supplies an `@PreDestroy` method that closes the pools, and thus the connections, when the application context is destroyed.

This has no effect in production; when the container exits, the whole JVM goes away and all of the database connections with it.

@nmalfroy I thought you might be particularly interested for TDR testing