### PR TITLE
[PF-2016] Stop logging auth headers

### DIFF
--- a/src/main/java/bio/terra/common/logging/RequestLoggingFilter.java
+++ b/src/main/java/bio/terra/common/logging/RequestLoggingFilter.java
@@ -177,6 +177,13 @@ class RequestLoggingFilter implements Filter {
   private Map<String, String> getRequestHeaders(HttpServletRequest request) {
     HttpHeaders headers = new ServletServerHttpRequest(request).getHeaders();
     return headers.entrySet().stream()
+        // Remove the "authorization" header, the "oidc_access_token" header populated by the proxy,
+        // and the oauth2_claim_access_token header to avoid logging access tokens.
+        .filter(
+            header ->
+                !header.getKey().equalsIgnoreCase("authorization")
+                    && !header.getKey().equalsIgnoreCase("oidc_access_token")
+                    && !header.getKey().equalsIgnoreCase("oauth2_claim_access_token"))
         .collect(
             Collectors.toMap(
                 Map.Entry::getKey, entry -> entry.getValue().stream().findFirst().orElse(null)));


### PR DESCRIPTION
While debugging a different issue I noticed we were including access tokens in logs, which we shouldn't do.