### PR TITLE
 [PF-2049] terra-common-lib: Remove paths ignore from Github workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ on:
     branches: [ develop ]
     paths-ignore: [ '**.md' ]
   pull_request:
+    # Branch settings require status checks before merging, so don't add paths-ignore.
     branches: [ '**' ]
-    paths-ignore: [ '**.md' ]
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
Follow-up on similar changes in Terra-cli - https://github.com/DataBiosphere/terra-cli/pull/327

---
Issue - If changeset only has .md files (readme.md for example) the PR check (github workflow) does not report the status as success skipped, thus leading to a PR that can't be merged

As a workaround remove this config for now
Further work will be carried out in https://broadworkbench.atlassian.net/browse/PF-2048

