### PR TITLE
[PF-2697] Use new version of Stairway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 
     // Terra libraries
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-f554115'
-    api group: 'bio.terra', name: 'stairway-gcp', version: '0.0.74-SNAPSHOT'
+    api group: 'bio.terra', name: 'stairway-gcp', version: '0.0.76-SNAPSHOT'
 
     // Logging
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra:stairway-gcp:0.0.74-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-bio.terra:stairway:0.0.74-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:stairway-gcp:0.0.76-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra:stairway:0.0.76-SNAPSHOT=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback.contrib:logback-jackson:0.1.5=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback.contrib:logback-json-classic:0.1.5=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback.contrib:logback-json-core:0.1.5=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/local-dev/local-postgres-init.sql
+++ b/local-dev/local-postgres-init.sql
@@ -2,3 +2,6 @@ CREATE DATABASE testdb;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
 CREATE DATABASE tclstairway;
 CREATE ROLE tclstairwayuser WITH LOGIN ENCRYPTED PASSWORD 'tclstairwaypwd';
+GRANT ALL ON DATABASE tclstairway TO tclstairwayuser WITH GRANT OPTION;
+\c tclstairway
+GRANT ALL ON SCHEMA public TO tclstairwayuser WITH GRANT OPTION;


### PR DESCRIPTION
I also fixed the database initialization script to grant permissions to the tclstairwayuser. Otherwise, the liquibase steps do not have permission to run.