### PR TITLE
[IA-4756] remove spring.factories

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-# Auto Configuration
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-bio.terra.common.tracing.disable.AutoConfigDisable


### PR DESCRIPTION
The `bio.terra.common.tracing.disable.AutoConfigDisable` file was previously removed in https://github.com/DataBiosphere/terra-common-lib/pull/119 and so we should remove any configuration based on this file.

This is a follow up from the work being done to upgrade the terra azure rely listener repo to the latest TCL https://broadworkbench.atlassian.net/browse/IA-4756