### PR TITLE
[WOR-1502] Update "main" branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       interval: "monthly"
       time: "06:00"
       timezone: "America/New_York"
-    target-branch: "main"
+    target-branch: "develop"
     reviewers:
       - "@DataBiosphere/platform-foundation-codeowners"
     labels:


### PR DESCRIPTION
There is a main branch in terra-common-lib, but it only has 1 commit… perhaps as part of our repo standardization we can also standardize on this?