### PR TITLE
[PF-2983] Minor version upgrades that should be low risk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
     id 'java-library'
     id 'maven-publish'
 
-    id 'com.diffplug.spotless' version '6.16.0'
+    id 'com.diffplug.spotless' version '6.25.0'
     id 'com.github.ben-manes.versions' version '0.42.0'
     id 'com.jfrog.artifactory' version '5.1.14'
-    id 'org.sonarqube' version '4.0.0.2929'
+    id 'org.sonarqube' version '4.4.1.3373'
     // [dd 2021-05-17] Use of Spring dependency management generates invalid POM, making
     // it impossible to publish to mavenLocal. In order to make TCL testable, I have
     // removed this plugin and filled in specific version numbers. I also removed all
@@ -121,11 +121,11 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test:3.1.2') {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.0'
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.0'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.10.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.2'
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.10.0'
-    testImplementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.3'
+    testImplementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
     // Transitive dependency constraints due to security vulnerabilities in prior versions.

--- a/src/main/java/bio/terra/common/flagsmith/FlagsmithService.java
+++ b/src/main/java/bio/terra/common/flagsmith/FlagsmithService.java
@@ -41,7 +41,7 @@ public class FlagsmithService {
    * @param feature the name of the feature
    */
   public Optional<Boolean> isFeatureEnabled(String feature) {
-    return isFeatureEnabled(feature, /*userEmail=*/ null);
+    return isFeatureEnabled(feature, /* userEmail= */ null);
   }
 
   /**
@@ -78,7 +78,7 @@ public class FlagsmithService {
    * return {@code Optional.empty()}.
    */
   public <T> Optional<T> getFeatureValueJson(String feature, Class<T> clazz) {
-    return getFeatureValueJson(feature, clazz, /*userEmail=*/ null);
+    return getFeatureValueJson(feature, clazz, /* userEmail= */ null);
   }
 
   /**

--- a/src/main/java/bio/terra/common/stairway/MetricsHelper.java
+++ b/src/main/java/bio/terra/common/stairway/MetricsHelper.java
@@ -25,8 +25,10 @@ public class MetricsHelper {
   public static final AttributeKey<String> KEY_STEP_DIRECTION =
       AttributeKey.stringKey("step_direction");
   public static final AttributeKey<String> KEY_ERROR = AttributeKey.stringKey("error_code");
+
   /** Unit string for count. */
   private static final String COUNT = "1";
+
   /** Unit string for millisecond. */
   private static final String MILLISECOND = "ms";
 
@@ -41,10 +43,13 @@ public class MetricsHelper {
 
   /** Gauge for flight latency in milliseconds. */
   private final LongHistogram flightLatencyHistogram;
+
   /** Counter for number of errors from stairway flights. */
   private final LongCounter flightErrorCounter;
+
   /** Gauge for step latency in milliseconds. */
   private final LongHistogram stepLatencyHistogram;
+
   /** Counter for number of errors from stairway steps. */
   private final LongCounter stepErrorCounter;
 

--- a/src/test/java/bio/terra/common/sam/SamRetryTest.java
+++ b/src/test/java/bio/terra/common/sam/SamRetryTest.java
@@ -97,8 +97,8 @@ public class SamRetryTest {
           throw new ApiException(
               "testing",
               new SocketTimeoutException(),
-              /*statusCode=*/ 0,
-              /*responseHeaders=*/ null);
+              /* statusCode= */ 0,
+              /* responseHeaders= */ null);
         case 1:
           throw new ApiException(HttpStatus.SC_INTERNAL_SERVER_ERROR, "testing");
         case 2:

--- a/src/test/java/bio/terra/common/sam/exception/SamExceptionFactoryTest.java
+++ b/src/test/java/bio/terra/common/sam/exception/SamExceptionFactoryTest.java
@@ -46,8 +46,8 @@ public class SamExceptionFactoryTest {
             new ApiException(
                 "testing",
                 new SocketTimeoutException(),
-                /*statusCode=*/ 0,
-                /*responseHeaders=*/ null));
+                /* statusCode= */ 0,
+                /* responseHeaders= */ null));
     assertTrue(errorReportException instanceof SamTimeoutException);
   }
 

--- a/src/test/java/bio/terra/common/stairway/test/StairwayTestUtils.java
+++ b/src/test/java/bio/terra/common/stairway/test/StairwayTestUtils.java
@@ -21,8 +21,8 @@ public class StairwayTestUtils {
     try {
       Stairway stairway = builder.build();
       stairway.initialize(
-          makeDataSource(), /* forceCleanStart =*/ true, /* migrateUpgrade =*/ true);
-      stairway.recoverAndStart(/* obsoleteStairways =*/ null);
+          makeDataSource(), /* forceCleanStart= */ true, /* migrateUpgrade= */ true);
+      stairway.recoverAndStart(/* obsoleteStairways= */ null);
       return stairway;
     } catch (StairwayException | InterruptedException e) {
       throw new RuntimeException(


### PR DESCRIPTION
Pulls out some test and quality minor version upgrades from https://github.com/DataBiosphere/terra-common-lib/pull/134.


| Package | From | To |
| --- | --- | --- |
com.diffplug.spotless | 6.16.0 | 6.25.0 |
org.sonarqube | 4.0.0.2929 | 4.4.1.3373 |
[org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) |	5.9.0 | 5.10.2 |
[org.junit.jupiter:junit-jupiter-api](https://github.com/junit-team/junit5) |5.9.0 | 5.10.2 |
| [org.openapitools:jackson-databind-nullable](https://github.com/OpenAPITools/jackson-databind-nullable) | `0.2.3` | `0.2.6` |

Sonarcube: https://github.com/SonarSource/sonar-scanner-gradle/releases
JUnit change notes: https://github.com/junit-team/junit5/releases
Jackson change notes: https://github.com/OpenAPITools/jackson-databind-nullable/releases
