### PR TITLE
[PF-2983] Minor version spring updates.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.10.0'
-    testImplementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.3'
+    testImplementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
     // Transitive dependency constraints due to security vulnerabilities in prior versions.

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     // removed this plugin and filled in specific version numbers. I also removed all
     // version numbers with `+` in them. Was:
     //     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
-    id 'org.springframework.boot' version '3.1.2'
+    id 'org.springframework.boot' version '3.2.2'
     id 'ru.vyarus.quality' version '4.8.0'
 }
 
@@ -49,12 +49,12 @@ dependencies {
     testImplementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
 
     // Spring
-    implementation group: 'org.springframework', name: 'spring-context', version: '6.0.11'
-    implementation group: 'org.springframework', name: 'spring-core', version: '6.0.11'
+    implementation group: 'org.springframework', name: 'spring-context', version: '6.1.3'
+    implementation group: 'org.springframework', name: 'spring-core', version: '6.1.3'
     implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.5'
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jdbc', version: '3.1.2'
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.1.2'
-    annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '3.1.2'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jdbc', version: '3.2.2'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.2.2'
+    annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '3.2.2'
 
     // Misc. Services
     implementation group: 'io.kubernetes', name: 'client-java', version: '16.0.0'
@@ -114,11 +114,11 @@ dependencies {
     implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
 
     // these are required for tracing in tests
-    testImplementation 'org.springframework:spring-aop:6.0.11'
-    testImplementation 'org.springframework:spring-aspects:6.0.11'
+    testImplementation 'org.springframework:spring-aop:6.1.3'
+    testImplementation 'org.springframework:spring-aspects:6.1.3'
 
     // Testing
-    testImplementation('org.springframework.boot:spring-boot-starter-test:3.1.2') {
+    testImplementation('org.springframework.boot:spring-boot-starter-test:3.2.2') {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.10.0'
-    testImplementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
+    testImplementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
     // Transitive dependency constraints due to security vulnerabilities in prior versions.
@@ -134,7 +134,7 @@ dependencies {
     constraints {
         implementation('org.scala-lang:scala-library:2.13.10')
         implementation('org.json:json:20230227')
-        implementation('org.bitbucket.b_c:jose4j:0.9.3')
+        implementation('org.bitbucket.b_c:jose4j:0.9.4')
         implementation('io.grpc:grpc-xds:1.53.0')
     }
 }


### PR DESCRIPTION
Pulled out of https://github.com/DataBiosphere/terra-common-lib/pull/134 to lower risk.

| Package | From | To |
| --- | --- | --- |
| [org.springframework:spring-aop](https://github.com/spring-projects/spring-framework) | `6.0.11` | `6.1.3` |
| [org.springframework:spring-aspects](https://github.com/spring-projects/spring-framework) | `6.0.11` | `6.1.3` |
| [org.springframework.boot:spring-boot-starter-test](https://github.com/spring-projects/spring-boot) | `3.1.2` | `3.2.2` |
| [org.springframework:spring-context](https://github.com/spring-projects/spring-framework) | `6.0.11` | `6.1.3` |
| [org.springframework:spring-core](https://github.com/spring-projects/spring-framework) | `6.0.11` | `6.1.3` |
| [org.springframework.boot:spring-boot-starter-data-jdbc](https://github.com/spring-projects/spring-boot) | `3.1.2` | `3.2.2` |
| [org.springframework.boot:spring-boot-starter-web](https://github.com/spring-projects/spring-boot) | `3.1.2` | `3.2.2` |
| [org.springframework.boot:spring-boot-configuration-processor](https://github.com/spring-projects/spring-boot) | `3.1.2` | `3.2.2` |
| [org.springframework.boot](https://github.com/spring-projects/spring-boot) | `3.1.2` | `3.2.2` |

Updates `org.springframework:spring-aop` from 6.0.11 to 6.1.3
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-framework/releases">org.springframework:spring-aop's releases</a>.</em></p>
<blockquote>
<h2>v6.1.3</h2>
<h2>:star: New Features</h2>
<ul>
<li>Perform checks for bean validation constraints in HandlerMethod only when needed <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32007">#32007</a></li>
<li>Exclude URI query from remaining WebClient checkpoints <a href="https://redirect.github.com/spring-projects/spring-framework/pull/31992">#31992</a></li>
<li>Avoid early getMostSpecificMethod resolution in CommonAnnotationBeanPostProcessor <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31967">#31967</a></li>
<li>Introduce <code>processInjection()</code> in <code>CommonAnnotationBeanPostProcessor</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31956">#31956</a></li>
<li>Make maximum length of SpEL expressions in an <code>ApplicationContext</code> configurable <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31952">#31952</a></li>
<li><code>JdkClientHttpRequest</code> may block indefinitely <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31911">#31911</a></li>
<li>Allow <code>Propagation.NOT\_SUPPORTED</code> with <code>@TransactionalEventListener</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31907">#31907</a></li>
<li>Review HibernateJpaVendorAdapter to align dialect to use for recent Hibernate versions <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31896">#31896</a></li>
<li>Improve method validation support for containers with constraints on container elements  <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31887">#31887</a></li>
<li>Method validation is not triggered when constraints are applied to the elements of a List <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31870">#31870</a></li>
<li>Use standard String comparison in ExtendedBeanInfo.PropertyDescriptorComparator <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31866">#31866</a></li>
<li>Detect Jetty 12 &quot;max length exceeded&quot; message for <code>MaxUploadSizeExceededException</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31850">#31850</a></li>
<li>Ensure that Observation is stopped and Scope is closed in doReceiveAndExecute() <a href="https://redirect.github.com/spring-projects/spring-framework/pull/31798">#31798</a></li>
<li>Support the use of <code>@Resource</code> in test classes in AOT mode <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31733">#31733</a></li>
<li>Add support for configuring sslContext in StandardWebSocketClient <a href="https://redirect.github.com/spring-projects/spring-framework/issues/30680">#30680</a></li>
<li>Refine allocations for improved memory profile when creating a large amount of proxy instances <a href="https://redirect.github.com/spring-projects/spring-framework/issues/30499">#30499</a></li>
<li>Check ResponseStatusException reason as MessageSource code for ProblemDetail <a href="https://redirect.github.com/spring-projects/spring-framework/pull/30300">#30300</a></li>
<li><code>SpringValidatorAdapter</code> fails in <code>getRejectedValue</code> if <code>ValueExtractor</code> used in property path to unwrap a container type <a href="https://redirect.github.com/spring-projects/spring-framework/issues/29043">#29043</a></li>
<li>Add CORS support for Private Network Access <a href="https://redirect.github.com/spring-projects/spring-framework/issues/28546">#28546</a></li>
<li>Introduce NoOpTaskScheduler for disabling <code>@Scheduled</code> tasks in test setups <a href="https://redirect.github.com/spring-projects/spring-framework/issues/28073">#28073</a></li>
<li>MvcUriComponentsBuilder should resolve property placeholders in request mapping paths <a href="https://redirect.github.com/spring-projects/spring-framework/issues/26795">#26795</a></li>
<li>Allow SockJsUrlInfo to be overridden in SockJsClient <a href="https://redirect.github.com/spring-projects/spring-framework/issues/25888">#25888</a></li>
<li>Extending abstract class does not expose parameter annotations <a href="https://redirect.github.com/spring-projects/spring-framework/issues/25788">#25788</a></li>
<li>DatabasePopulatorConfigUtils should only set a populator if matching scripts are defined <a href="https://redirect.github.com/spring-projects/spring-framework/issues/23405">#23405</a></li>
<li><code>@annotation</code> pointcut is not matched with complex hierarchy and generics against classes compiled by Eclipse [SPR-17310] <a href="https://redirect.github.com/spring-projects/spring-framework/issues/21843">#21843</a></li>
<li>Allow registration of application event listeners in a functional way [SPR-16872] <a href="https://redirect.github.com/spring-projects/spring-framework/issues/21411">#21411</a></li>
<li>Allow CronTrigger to resume from specified timestamp [SPR-14909] <a href="https://redirect.github.com/spring-projects/spring-framework/issues/19475">#19475</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Using a URI variable for port in <code>WebClient</code> causes an <code>IllegalStateException</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32003">#32003</a></li>
<li>[spring-tx] Unable to override prepareSynchronization of AbstractPlatformTransactionManager from v6.1.0 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32000">#32000</a></li>
<li><code>RestClientResponseException</code> handles <code>responseHeaders</code> case-sensitive <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31978">#31978</a></li>
<li>CronTrigger hard-codes default ZoneId instead of participating in scheduler-wide Clock setup <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31948">#31948</a></li>
<li>HandlerMappingIntrospector is throwing PatternSyntaxException for wildcards in the request URL <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31937">#31937</a></li>
<li>java.lang.NullPointerException with Scheduled tasks through DefaultScheduledTaskObservationConvention <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31918">#31918</a></li>
<li>HibernateJpaVendorAdapter refers to org.hibernate.dialect.Oracle12cDialect that does not exist in recent Hibernate versions <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31892">#31892</a></li>
<li>ClassNotFoundException: org.hibernate.dialect.MySQL57Dialect with Hibernate 6.4 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31889">#31889</a></li>
<li>Inconsistent inclusion of base URL in <code>WebClient</code> URI template attribute since Spring WebFlux 6.1.2 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31882">#31882</a></li>
<li><code>@Async</code> does not support <code>Unit?</code> return type <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31881">#31881</a></li>
<li>Web handlers don't support Kotlin extensions <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31876">#31876</a></li>
<li>DefaultDataBuffer fails to transform its content to a string <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31873">#31873</a></li>
<li>With XML configuration, setter selection can be random in case of overloaded setter methods (e.g. on SimpleClientHttpRequestFactory in 6.1) <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31872">#31872</a></li>
<li>Complete frame callback when opcode is not PONG <a href="https://redirect.github.com/spring-projects/spring-framework/pull/31869">#31869</a></li>
<li><code>@Cacheable</code> does not respect cache hit when empty Mono/Flux response is returned <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31868">#31868</a></li>
<li>Unable to use sync cache with reactivestreams <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31861">#31861</a></li>
<li>Spring Websocket - JettyWebsocketHandlerAdapter copyByteBuffer fills Buffer with zeros <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31857">#31857</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-framework/commit/b19f98bfd24bebbeaf5a5be44363e5484a0ff370"><code>b19f98b</code></a> Release v6.1.3</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/50fad9ed059fc37e8ca543c6aa0546c0511eb1e1"><code>50fad9e</code></a> Lenient port handling in HierarchicalUriComponents#toUriString</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/2b4ffe03915187746c30d76f69c1f27bf1af0895"><code>2b4ffe0</code></a> Consistent inclusion of baseUrl in URI_TEMPLATE attribute</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/e7eaaaded1060f52dbe8530c1715fc33849d700a"><code>e7eaaad</code></a> Explicit initialization of shouldValidate flags</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/f6e52900a289d9aa2d93c6b0ad4f24b52c11cc4c"><code>f6e5290</code></a> Polish SpEL documentation</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/62b5e4276975ab180617f7d887d1fc6362e67172"><code>62b5e42</code></a> Fix syntax for disabled selection/projection tests in ParsingTests</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/1631be5660fa61faa88264aa253e4fef32f55b24"><code>1631be5</code></a> Provide guidelines in AspectJ documentation to avoid dumps</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/9ccc72a9fbd8784ab37872737f58673d44a8f5c4"><code>9ccc72a</code></a> Upgrade to spring-javaformat-checkstyle 0.0.41</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/01b28561149127eeb7c7ec5d3977d83877cee6d4"><code>01b2856</code></a> Document Kotlin internal modifier impact on <code>@Bean</code></li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/6dca7b28ccbcf4221a1eeeea68e7abd3ec07862f"><code>6dca7b2</code></a> Polishing contribution</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-framework/compare/v6.0.11...v6.1.3">compare view</a></li>
</ul>
</details>
<br />

Updates `org.springframework:spring-aspects` from 6.0.11 to 6.1.3
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-framework/releases">org.springframework:spring-aspects's releases</a>.</em></p>
<blockquote>
<h2>v6.1.3</h2>
<h2>:star: New Features</h2>
<ul>
<li>Perform checks for bean validation constraints in HandlerMethod only when needed <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32007">#32007</a></li>
<li>Exclude URI query from remaining WebClient checkpoints <a href="https://redirect.github.com/spring-projects/spring-framework/pull/31992">#31992</a></li>
<li>Avoid early getMostSpecificMethod resolution in CommonAnnotationBeanPostProcessor <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31967">#31967</a></li>
<li>Introduce <code>processInjection()</code> in <code>CommonAnnotationBeanPostProcessor</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31956">#31956</a></li>
<li>Make maximum length of SpEL expressions in an <code>ApplicationContext</code> configurable <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31952">#31952</a></li>
<li><code>JdkClientHttpRequest</code> may block indefinitely <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31911">#31911</a></li>
<li>Allow <code>Propagation.NOT\_SUPPORTED</code> with <code>@TransactionalEventListener</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31907">#31907</a></li>
<li>Review HibernateJpaVendorAdapter to align dialect to use for recent Hibernate versions <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31896">#31896</a></li>
<li>Improve method validation support for containers with constraints on container elements  <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31887">#31887</a></li>
<li>Method validation is not triggered when constraints are applied to the elements of a List <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31870">#31870</a></li>
<li>Use standard String comparison in ExtendedBeanInfo.PropertyDescriptorComparator <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31866">#31866</a></li>
<li>Detect Jetty 12 &quot;max length exceeded&quot; message for <code>MaxUploadSizeExceededException</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31850">#31850</a></li>
<li>Ensure that Observation is stopped and Scope is closed in doReceiveAndExecute() <a href="https://redirect.github.com/spring-projects/spring-framework/pull/31798">#31798</a></li>
<li>Support the use of <code>@Resource</code> in test classes in AOT mode <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31733">#31733</a></li>
<li>Add support for configuring sslContext in StandardWebSocketClient <a href="https://redirect.github.com/spring-projects/spring-framework/issues/30680">#30680</a></li>
<li>Refine allocations for improved memory profile when creating a large amount of proxy instances <a href="https://redirect.github.com/spring-projects/spring-framework/issues/30499">#30499</a></li>
<li>Check ResponseStatusException reason as MessageSource code for ProblemDetail <a href="https://redirect.github.com/spring-projects/spring-framework/pull/30300">#30300</a></li>
<li><code>SpringValidatorAdapter</code> fails in <code>getRejectedValue</code> if <code>ValueExtractor</code> used in property path to unwrap a container type <a href="https://redirect.github.com/spring-projects/spring-framework/issues/29043">#29043</a></li>
<li>Add CORS support for Private Network Access <a href="https://redirect.github.com/spring-projects/spring-framework/issues/28546">#28546</a></li>
<li>Introduce NoOpTaskScheduler for disabling <code>@Scheduled</code> tasks in test setups <a href="https://redirect.github.com/spring-projects/spring-framework/issues/28073">#28073</a></li>
<li>MvcUriComponentsBuilder should resolve property placeholders in request mapping paths <a href="https://redirect.github.com/spring-projects/spring-framework/issues/26795">#26795</a></li>
<li>Allow SockJsUrlInfo to be overridden in SockJsClient <a href="https://redirect.github.com/spring-projects/spring-framework/issues/25888">#25888</a></li>
<li>Extending abstract class does not expose parameter annotations <a href="https://redirect.github.com/spring-projects/spring-framework/issues/25788">#25788</a></li>
<li>DatabasePopulatorConfigUtils should only set a populator if matching scripts are defined <a href="https://redirect.github.com/spring-projects/spring-framework/issues/23405">#23405</a></li>
<li><code>@annotation</code> pointcut is not matched with complex hierarchy and generics against classes compiled by Eclipse [SPR-17310] <a href="https://redirect.github.com/spring-projects/spring-framework/issues/21843">#21843</a></li>
<li>Allow registration of application event listeners in a functional way [SPR-16872] <a href="https://redirect.github.com/spring-projects/spring-framework/issues/21411">#21411</a></li>
<li>Allow CronTrigger to resume from specified timestamp [SPR-14909] <a href="https://redirect.github.com/spring-projects/spring-framework/issues/19475">#19475</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Using a URI variable for port in <code>WebClient</code> causes an <code>IllegalStateException</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32003">#32003</a></li>
<li>[spring-tx] Unable to override prepareSynchronization of AbstractPlatformTransactionManager from v6.1.0 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32000">#32000</a></li>
<li><code>RestClientResponseException</code> handles <code>responseHeaders</code> case-sensitive <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31978">#31978</a></li>
<li>CronTrigger hard-codes default ZoneId instead of participating in scheduler-wide Clock setup <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31948">#31948</a></li>
<li>HandlerMappingIntrospector is throwing PatternSyntaxException for wildcards in the request URL <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31937">#31937</a></li>
<li>java.lang.NullPointerException with Scheduled tasks through DefaultScheduledTaskObservationConvention <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31918">#31918</a></li>
<li>HibernateJpaVendorAdapter refers to org.hibernate.dialect.Oracle12cDialect that does not exist in recent Hibernate versions <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31892">#31892</a></li>
<li>ClassNotFoundException: org.hibernate.dialect.MySQL57Dialect with Hibernate 6.4 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31889">#31889</a></li>
<li>Inconsistent inclusion of base URL in <code>WebClient</code> URI template attribute since Spring WebFlux 6.1.2 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31882">#31882</a></li>
<li><code>@Async</code> does not support <code>Unit?</code> return type <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31881">#31881</a></li>
<li>Web handlers don't support Kotlin extensions <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31876">#31876</a></li>
<li>DefaultDataBuffer fails to transform its content to a string <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31873">#31873</a></li>
<li>With XML configuration, setter selection can be random in case of overloaded setter methods (e.g. on SimpleClientHttpRequestFactory in 6.1) <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31872">#31872</a></li>
<li>Complete frame callback when opcode is not PONG <a href="https://redirect.github.com/spring-projects/spring-framework/pull/31869">#31869</a></li>
<li><code>@Cacheable</code> does not respect cache hit when empty Mono/Flux response is returned <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31868">#31868</a></li>
<li>Unable to use sync cache with reactivestreams <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31861">#31861</a></li>
<li>Spring Websocket - JettyWebsocketHandlerAdapter copyByteBuffer fills Buffer with zeros <a href="https://redirect.github.com/spring-projects/spring-framework/issues/31857">#31857</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-framework/commit/b19f98bfd24bebbeaf5a5be44363e5484a0ff370"><code>b19f98b</code></a> Release v6.1.3</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/50fad9ed059fc37e8ca543c6aa0546c0511eb1e1"><code>50fad9e</code></a> Lenient port handling in HierarchicalUriComponents#toUriString</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/2b4ffe03915187746c30d76f69c1f27bf1af0895"><code>2b4ffe0</code></a> Consistent inclusion of baseUrl in URI_TEMPLATE attribute</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/e7eaaaded1060f52dbe8530c1715fc33849d700a"><code>e7eaaad</code></a> Explicit initialization of shouldValidate flags</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/f6e52900a289d9aa2d93c6b0ad4f24b52c11cc4c"><code>f6e5290</code></a> Polish SpEL documentation</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/62b5e4276975ab180617f7d887d1fc6362e67172"><code>62b5e42</code></a> Fix syntax for disabled selection/projection tests in ParsingTests</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/1631be5660fa61faa88264aa253e4fef32f55b24"><code>1631be5</code></a> Provide guidelines in AspectJ documentation to avoid dumps</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/9ccc72a9fbd8784ab37872737f58673d44a8f5c4"><code>9ccc72a</code></a> Upgrade to spring-javaformat-checkstyle 0.0.41</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/01b28561149127eeb7c7ec5d3977d83877cee6d4"><code>01b2856</code></a> Document Kotlin internal modifier impact on <code>@Bean</code></li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/6dca7b28ccbcf4221a1eeeea68e7abd3ec07862f"><code>6dca7b2</code></a> Polishing contribution</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-framework/compare/v6.0.11...v6.1.3">compare view</a></li>
</ul>
</details>
<br />

Updates `org.springframework.boot:spring-boot-starter-test` from 3.1.2 to 3.2.2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-test's releases</a>.</em></p>
<blockquote>
<h2>v3.2.2</h2>
<h2>⚠️ Noteworthy Changes</h2>
<ul>
<li>Automatically enabling support for Micrometer's observation annotations when AspectJ is on the classpath has proven to be too much. A new property, <code>management.observations.annotations.enabled</code>, has been introduced. It defaults to <code>false</code>. Set it to <code>true</code> to restore the previous behavior <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39128">#39128</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>SslBundle implementations do not provide useful toString() results <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39167">#39167</a></li>
<li>JarEntry.getComment() returns incorrect result from NestedJarFile instances <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39166">#39166</a></li>
<li>Mixing PEM and JKS certificate material in server.ssl properties does not work <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39158">#39158</a></li>
<li>Having AspectJ and Micrometer on the classpath is not a strong enough signal to enable support for Micrometer observation annotations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39128">#39128</a></li>
<li>Actuator endpoints with no operations that use selectors are not accessible when mapped to / <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39122">#39122</a></li>
<li>Spring Boot 3.2 app that uses WebFlux, Security, and Actuator may fail to start due to a missing authentication manager <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39096">#39096</a></li>
<li>management.observations.http.server.requests.name no longer has any effect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39083">#39083</a></li>
<li>spring.rabbitmq.listener.stream.auto-startup property has no effect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39078">#39078</a></li>
<li>Error mark in the log message for PatternParseException is in the wrong place <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39075">#39075</a></li>
<li>Configuring server.jetty.max-connections has no effect <a href="https://redirect.github.com/spring-projects/spring-boot/pull/39052">#39052</a></li>
<li><code>@ConfigurationPropertiesBinding</code> converters that rely on initial CharSequence to String conversion no longer work <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39051">#39051</a></li>
<li>Manifest attributes cannot be resolved with the new loader implementation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38996">#38996</a></li>
<li>Throwable from logging system initialization may result in the application silently failing to start <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38963">#38963</a></li>
<li>When using Jetty, idle timeout for IO operations and delayed dispatch cannot be set to less than 30000ms <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38960">#38960</a></li>
<li>spring-boot-maven-plugin repackage uber jar execution fails when jar is put on WSL network drive <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38956">#38956</a></li>
<li>Oracle OJDBC BOM version is flagged not for production use <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38943">#38943</a></li>
<li>Connection leak when using jOOQ and spring.jooq.sql-dialect has not been set <a href="https://redirect.github.com/spring-projects/spring-boot/pull/38924">#38924</a></li>
<li>AutoConfigurationSorter does not always respect <code>@AutoConfigureOrder</code>(Ordered.LOWEST_PRECEDENCE) <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38916">#38916</a></li>
<li>Containers are not started when using <code>@ImportTestcontainers</code> <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38913">#38913</a></li>
<li>Even when spring.security.user.name or spring.security.user.password has been configured, user details auto-configuration still backs off when resource server is on the classpath  <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38864">#38864</a></li>
<li>MockRestServiceServerAutoConfiguration with RestTemplate and RestClient together throws incorrect exception <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38820">#38820</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Improve &quot;Sanitize Sensitive Values&quot; section in reference documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39199">#39199</a></li>
<li>Fix link to Log4j2's JDK logging adapter documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39171">#39171</a></li>
<li>Update CRaC support status link <a href="https://redirect.github.com/spring-projects/spring-boot/pull/39170">#39170</a></li>
<li>Remove entry for OCI starter as it is no longer maintained <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39165">#39165</a></li>
<li>Update links to Micrometer docs in metrics section of reference docs <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39149">#39149</a></li>
<li>Use the term &quot;tags&quot; in documentation consistently <a href="https://redirect.github.com/spring-projects/spring-boot/pull/39125">#39125</a></li>
<li>Correct the documentation on injecting dependencies into FailureAnalyzer implementations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39100">#39100</a></li>
<li>Polish reference documentation <a href="https://redirect.github.com/spring-projects/spring-boot/pull/38942">#38942</a></li>
<li>Document virtual threads limitations <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38883">#38883</a></li>
</ul>
<h2>:hammer: Dependency Upgrades</h2>
<ul>
<li>Upgrade to MySQL 8.3.0 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39081">#39081</a></li>
<li>Upgrade to Byte Buddy 1.14.11 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39184">#39184</a></li>
<li>Upgrade to Groovy 4.0.17 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39185">#39185</a></li>
<li>Upgrade to jOOQ 3.18.9 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39186">#39186</a></li>
<li>Upgrade to Kotlin 1.9.22 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39187">#39187</a></li>
<li>Upgrade to Lettuce 6.3.1.RELEASE <a href="https://redirect.github.com/spring-projects/spring-boot/issues/39188">#39188</a></li>
<li>Upgrade to MariaDB 3.3.2 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/38901">#38901</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/80c1e663ce4caae9ba4d797658c0b8c15bf96374"><code>80c1e66</code></a> Release v3.2.2</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/f2362d3f8c9163426ec1c25e3061bb69563a11f5"><code>f2362d3</code></a> Merge branch '3.1.x' into 3.2.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/663a0e66232562b012102e1fdbdc0f81783412ba"><code>663a0e6</code></a> Add missing harbor vars</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/1a427767bf9d2d6dc2f31c150d91a77d47829250"><code>1a42776</code></a> Merge branch '3.1.x' into 3.2.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/580865bdb99e0e9365d956ef6fcbb15ea2a111ff"><code>580865b</code></a> Next development version (v3.1.9-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/3fad814692984cb8d9308e5d9a499452b0112d5a"><code>3fad814</code></a> Merge branch '3.1.x' into 3.2.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/7f9bd1cd6c2e4ddded20bae149b436bc2745e137"><code>7f9bd1c</code></a> Switch harbor push location</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/5a900377ef2b5f355a90dfa8c8f5d33cd9027bd4"><code>5a90037</code></a> Merge branch '3.1.x' into 3.2.x</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/9e2a312224308dccb3bd7479476ea8520b22ff14"><code>9e2a312</code></a> Update CI to use harbor</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/961da4e4280d6468a826e68e974a21b93db3b3ca"><code>961da4e</code></a> Make user details only back off without custom username or password</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v3.1.2...v3.2.2">compare view</a></li>
</ul>
</details>
<br />

