### PR TITLE
[PF-2983, PF-2978] Remove logback override now that spring boot is updated.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,3 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[PF-2983]"
-    ignore:
-      - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"

--- a/build.gradle
+++ b/build.gradle
@@ -88,8 +88,6 @@ dependencies {
     implementation group: 'com.google.apis', name: 'google-api-services-logging', version: 'v2-rev20240207-2.0.0'
     implementation group: 'ch.qos.logback.contrib', name: 'logback-json-classic', version: '0.1.5'
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.0'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.0'
 
     // Flagsmith
     implementation group: 'com.flagsmith', name: 'flagsmith-java-client', version: '6.1.0'


### PR DESCRIPTION
Followup to https://github.com/DataBiosphere/terra-common-lib/pull/127, now that spring-boot is updated and is using the non-vulnerable version (1.4.14).

Output of `./gradlew dependencyInsight --dependency ch.qos.logback`

```
> Task :dependencyInsight
ch.qos.logback:logback-classic:1.4.14
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |
   Selection reasons:
      - By conflict resolution: between versions 1.4.14 and 1.1.3

ch.qos.logback:logback-classic:1.4.14
\--- org.springframework.boot:spring-boot-starter-logging:3.2.3
     \--- org.springframework.boot:spring-boot-starter:3.2.3
          +--- org.springframework.boot:spring-boot-starter-web:3.2.3
          |    \--- compileClasspath
          +--- org.springframework.boot:spring-boot-starter-jdbc:3.2.3
          |    \--- org.springframework.boot:spring-boot-starter-data-jdbc:3.2.3
          |         \--- compileClasspath
          \--- org.springframework.boot:spring-boot-starter-json:3.2.3
               \--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)

ch.qos.logback:logback-classic:1.1.3 -> 1.4.14
\--- ch.qos.logback.contrib:logback-json-classic:0.1.5
     \--- compileClasspath

ch.qos.logback:logback-core:1.4.14
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |
   Selection reasons:
      - By conflict resolution: between versions 1.4.14 and 1.1.3

ch.qos.logback:logback-core:1.4.14
\--- ch.qos.logback:logback-classic:1.4.14
     +--- ch.qos.logback.contrib:logback-json-classic:0.1.5 (requested ch.qos.logback:logback-classic:1.1.3)
     |    \--- compileClasspath
     \--- org.springframework.boot:spring-boot-starter-logging:3.2.3
          \--- org.springframework.boot:spring-boot-starter:3.2.3
               +--- org.springframework.boot:spring-boot-starter-web:3.2.3
               |    \--- compileClasspath
               +--- org.springframework.boot:spring-boot-starter-jdbc:3.2.3
               |    \--- org.springframework.boot:spring-boot-starter-data-jdbc:3.2.3
               |         \--- compileClasspath
               \--- org.springframework.boot:spring-boot-starter-json:3.2.3
                    \--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)

ch.qos.logback:logback-core:1.1.3 -> 1.4.14
\--- ch.qos.logback.contrib:logback-json-core:0.1.5
     +--- ch.qos.logback.contrib:logback-json-classic:0.1.5
     |    \--- compileClasspath
     \--- ch.qos.logback.contrib:logback-jackson:0.1.5
          \--- compileClasspath

ch.qos.logback.contrib:logback-jackson:0.1.5
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |

ch.qos.logback.contrib:logback-jackson:0.1.5
\--- compileClasspath

ch.qos.logback.contrib:logback-json-classic:0.1.5
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |

ch.qos.logback.contrib:logback-json-classic:0.1.5
\--- compileClasspath

ch.qos.logback.contrib:logback-json-core:0.1.5
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |

ch.qos.logback.contrib:logback-json-core:0.1.5
+--- ch.qos.logback.contrib:logback-jackson:0.1.5
|    \--- compileClasspath
\--- ch.qos.logback.contrib:logback-json-classic:0.1.5
     \--- compileClasspath
