### PR TITLE
ID-1105 Remediate CVE-2024-26308 (Apache Commons Compress) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,8 @@ dependencies {
         implementation('org.json:json:20240205')
         implementation('org.bitbucket.b_c:jose4j:0.9.5')
         implementation('io.grpc:grpc-xds:1.61.1')
+        // commons-compress comes from io.kubernetes:client-java, which doesn't yet have a version
+        // that pulls in the non-vulnerable version of commons-compress.
         implementation('org.apache.commons:commons-compress:1.26.0')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ dependencies {
         implementation('org.json:json:20240205')
         implementation('org.bitbucket.b_c:jose4j:0.9.5')
         implementation('io.grpc:grpc-xds:1.61.1')
+        implementation('org.apache.commons:commons-compress:1.26.0')
     }
 }
 


### PR DESCRIPTION
Forcing Apache Commons Compress to version 1.26.0 to remediate https://nvd.nist.gov/vuln/detail/CVE-2024-26308