### PR TITLE
[WOR-1560] Derive opentelemetry versions from BOMs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,24 +89,26 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-json-classic', version: '0.1.5'
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
-    // OpenTelemetry
-    var openTelemetryVersion = '1.34.1'
-    var openTelemetryInstrumentationVersion = '2.0.0'
-    implementation "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}"
-    implementation "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}"
-    implementation "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}"
-    implementation "io.opentelemetry:opentelemetry-exporter-logging:${openTelemetryVersion}"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-6.0:${openTelemetryInstrumentationVersion}-alpha"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${openTelemetryInstrumentationVersion}"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:${openTelemetryInstrumentationVersion}"
-    implementation "io.opentelemetry.instrumentation:opentelemetry-spring-boot:${openTelemetryInstrumentationVersion}-alpha"
-    implementation "io.opentelemetry:opentelemetry-exporter-prometheus:${openTelemetryVersion}-alpha"
-    implementation "io.opentelemetry:opentelemetry-extension-incubator:${openTelemetryVersion}-alpha"
+    // OpenTelemetry BOMs
+    implementation platform('io.opentelemetry:opentelemetry-bom:1.36.0')
+    implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.36.0-alpha')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.2.0')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.2.0-alpha')
+    // OpenTelemetry dependencies versioned by BOMs
+    api 'io.opentelemetry:opentelemetry-api'
+    implementation 'io.opentelemetry:opentelemetry-sdk'
+    implementation 'io.opentelemetry:opentelemetry-sdk-metrics'
+    implementation 'io.opentelemetry:opentelemetry-exporter-logging'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-6.0'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot'
+    implementation 'io.opentelemetry:opentelemetry-exporter-prometheus'
+    implementation 'io.opentelemetry:opentelemetry-extension-incubator'
 
     // Google cloud open telemetry exporters
-    var gcpOpenTelemetryExporterVersion = '0.27.0'
-    implementation "com.google.cloud.opentelemetry:exporter-trace:${gcpOpenTelemetryExporterVersion}"
-    implementation "com.google.cloud.opentelemetry:exporter-metrics:${gcpOpenTelemetryExporterVersion}"
+    implementation 'com.google.cloud.opentelemetry:exporter-trace:0.27.0'
+    implementation 'com.google.cloud.opentelemetry:exporter-metrics:0.27.0'
 
     // these are required for tracing in tests
     testImplementation 'org.springframework:spring-aop:6.1.4'

--- a/build.gradle
+++ b/build.gradle
@@ -90,10 +90,10 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
     // OpenTelemetry BOMs
-    implementation platform('io.opentelemetry:opentelemetry-bom:1.36.0')
-    implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.36.0-alpha')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.2.0')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.2.0-alpha')
+    implementation platform('io.opentelemetry:opentelemetry-bom:1.34.1')
+    implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.34.1-alpha')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.0.0')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.0.0-alpha')
     // OpenTelemetry dependencies versioned by BOMs
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-sdk'

--- a/src/main/java/bio/terra/common/opentelemetry/HttpMetricsAdvice.java
+++ b/src/main/java/bio/terra/common/opentelemetry/HttpMetricsAdvice.java
@@ -9,13 +9,14 @@ import static java.util.Arrays.asList;
 
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleHistogramBuilder;
+import io.opentelemetry.instrumentation.api.semconv.http.internal.HttpAttributes;
 import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.List;
 import java.util.stream.DoubleStream;
 
 /**
  * copied from <a
- * href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.2.x/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpMetricsAdvice.java">HttpMetricsAdvice</a>
+ * href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.0.x/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpMetricsAdvice.java">HttpMetricsAdvice</a>
  * for the only purpose of overriding the DURATION_SECONDS_BUCKETS
  */
 final class HttpMetricsAdvice {
@@ -53,7 +54,7 @@ final class HttpMetricsAdvice {
             asList(
                 SemanticAttributes.HTTP_REQUEST_METHOD,
                 SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
-                SemanticAttributes.ERROR_TYPE,
+                HttpAttributes.ERROR_TYPE,
                 SemanticAttributes.NETWORK_PROTOCOL_NAME,
                 SemanticAttributes.NETWORK_PROTOCOL_VERSION,
                 SemanticAttributes.SERVER_ADDRESS,
@@ -70,7 +71,7 @@ final class HttpMetricsAdvice {
                 SemanticAttributes.HTTP_ROUTE,
                 SemanticAttributes.HTTP_REQUEST_METHOD,
                 SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
-                SemanticAttributes.ERROR_TYPE,
+                HttpAttributes.ERROR_TYPE,
                 SemanticAttributes.NETWORK_PROTOCOL_NAME,
                 SemanticAttributes.NETWORK_PROTOCOL_VERSION,
                 SemanticAttributes.URL_SCHEME));

--- a/src/main/java/bio/terra/common/opentelemetry/HttpMetricsAdvice.java
+++ b/src/main/java/bio/terra/common/opentelemetry/HttpMetricsAdvice.java
@@ -9,14 +9,13 @@ import static java.util.Arrays.asList;
 
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleHistogramBuilder;
-import io.opentelemetry.instrumentation.api.semconv.http.internal.HttpAttributes;
 import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.List;
 import java.util.stream.DoubleStream;
 
 /**
  * copied from <a
- * href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.0.x/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpMetricsAdvice.java">HttpMetricsAdvice</a>
+ * href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.2.x/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpMetricsAdvice.java">HttpMetricsAdvice</a>
  * for the only purpose of overriding the DURATION_SECONDS_BUCKETS
  */
 final class HttpMetricsAdvice {
@@ -54,7 +53,7 @@ final class HttpMetricsAdvice {
             asList(
                 SemanticAttributes.HTTP_REQUEST_METHOD,
                 SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
-                HttpAttributes.ERROR_TYPE,
+                SemanticAttributes.ERROR_TYPE,
                 SemanticAttributes.NETWORK_PROTOCOL_NAME,
                 SemanticAttributes.NETWORK_PROTOCOL_VERSION,
                 SemanticAttributes.SERVER_ADDRESS,
@@ -71,7 +70,7 @@ final class HttpMetricsAdvice {
                 SemanticAttributes.HTTP_ROUTE,
                 SemanticAttributes.HTTP_REQUEST_METHOD,
                 SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
-                HttpAttributes.ERROR_TYPE,
+                SemanticAttributes.ERROR_TYPE,
                 SemanticAttributes.NETWORK_PROTOCOL_NAME,
                 SemanticAttributes.NETWORK_PROTOCOL_VERSION,
                 SemanticAttributes.URL_SCHEME));


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1560

When available, using a BOM (bill of materials) to synchronize related dependency versions makes it less likely that an incompatible upgrade is introduced.

Our OpenTelemetry dependencies can all be derived from [BOMs](https://github.com/open-telemetry/opentelemetry-java?tab=readme-ov-file#overview):
- [opentelemetry-bom](https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-bom) synchronizes stable `io.opentelemetry:*` dependencies
- [opentelemetry-bom-alpha](https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-bom-alpha) synchronizes unstable `io.opentelemetry:*` dependencies
- [opentelemetry-instrumentation-bom](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom) synchronizes stable `io.opentelemetry.instrumentation:*` dependencies
- [opentelemetry-instrumentation-bom-alpha](https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom-alpha) synchronizes unstable `io.opentelemetry.instrumentation:*` dependencies

We pulled in dependencies from all of the above BOMs.  They now derive their versions from these BOMs.

While here...
- Expose `io.opentelemetry:opentelemetry-api` as an `api` dependency rather than `implementation`, so that services pulling in TCL won't have to define it themselves.
- Reformatted dependency definitions so that Dependabot will register them: I think that Dependabot may not pick up on those formatted strings of ours.

I also tried to version BOMs for latest dependencies, which required a slight adjustment to our redefinition of HttpMetricsAdvice (I used the latest version of [OTEL source code's HttpMetricsAdvice](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.2.x/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpMetricsAdvice.java) as a reference).  **But**, [tests failed](https://scans.gradle.com/s/gjvj4cxmcaqss/tests/overview?outcome=FAILED) and I decided it was better to allow any upgrades to be handled separately from the move to BOMs for versioning.
