### PR TITLE
[WOR-1560] Add StairwayLoggingHook for reuse

### DIFF
--- a/src/main/java/bio/terra/common/stairway/StairwayLoggingHook.java
+++ b/src/main/java/bio/terra/common/stairway/StairwayLoggingHook.java
@@ -1,0 +1,68 @@
+package bio.terra.common.stairway;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.HookAction;
+import bio.terra.stairway.StairwayHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A {@link StairwayHook} which supplements logging at notable flight state transitions. */
+public class StairwayLoggingHook implements StairwayHook {
+  private static final Logger logger = LoggerFactory.getLogger(StairwayLoggingHook.class);
+  private static final String FLIGHT_LOG_FORMAT = "Operation: {}, flightClass: {}, flightId: {}";
+  private static final String STEP_LOG_FORMAT =
+      "Operation: {}, flightClass: {}, flightId: {}, stepClass: {}, stepIndex: {}, direction: {}";
+
+  @Override
+  public HookAction startStep(FlightContext flightContext) {
+    logger.info(
+        STEP_LOG_FORMAT,
+        "startStep",
+        flightContext.getFlightClassName(),
+        flightContext.getFlightId(),
+        flightContext.getStepClassName(),
+        flightContext.getStepIndex(),
+        flightContext.getDirection().name());
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction endStep(FlightContext flightContext) {
+    logger.info(
+        STEP_LOG_FORMAT,
+        "endStep",
+        flightContext.getFlightClassName(),
+        flightContext.getFlightId(),
+        flightContext.getStepClassName(),
+        flightContext.getStepIndex(),
+        flightContext.getDirection().name());
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction startFlight(FlightContext flightContext) {
+    logger.info(
+        FLIGHT_LOG_FORMAT,
+        "startFlight",
+        flightContext.getFlightClassName(),
+        flightContext.getFlightId());
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction endFlight(FlightContext flightContext) {
+    logger.info(
+        FLIGHT_LOG_FORMAT,
+        "endFlight",
+        flightContext.getFlightClassName(),
+        flightContext.getFlightId());
+    return HookAction.CONTINUE;
+  }
+
+  @Override
+  public HookAction stateTransition(FlightContext context) {
+    logger.info(
+        "Flight ID {} changed status to {}.", context.getFlightId(), context.getFlightStatus());
+    return HookAction.CONTINUE;
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1560

This `StairwayHook` is similar to existing [MonitoringHook](https://github.com/DataBiosphere/terra-common-lib/blob/develop/src/main/java/bio/terra/common/stairway/MonitoringHook.java) (not a Spring component, [consumers can construct it directly when initializing their Stairways](https://github.com/DataBiosphere/terra-landing-zone-service/blob/736ab8b3950fb2065aafc7b4b008b3a683b8677d/library/src/main/java/bio/terra/landingzone/job/LandingZoneJobService.java#L180)).

Adding this hook to TCL minimizes code duplication across services and removes a potential for autowiring conflicts between services that both define their own StairwayLoggingHooks as Spring components (ex. [WSM and LZS](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/8437022333/job/23105828681?pr=1684), the former pulls in the latter).

**Follow-On Work**
- Upgrade TCL in LZS, WSM and others on TCL >= 1.0.9 to remove their `StairwayLoggingHook` components in favor of common version