### PR TITLE
[PF-3000] Version io.kubernetes:client-java at 20.0.1-legacy instead of 20.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[PF-2983]"
+    ignore:
+      # PF-3000: k8s client versions 20.0.0 onward without '-legacy' suffix include breaking changes
+      - dependency-name: "io.kubernetes:client-java"

--- a/README.md
+++ b/README.md
@@ -69,3 +69,36 @@ build.gradle file (e.g. before `mavenCentral()`.
 
 That's it! Your service should pick up locally-published changes. If your changes involved bumping 
 a minor version of a TCL package, be careful to update version numbers accordingly.
+
+## SourceClear
+
+[SourceClear](https://srcclr.github.io) is a static analysis tool that scans a project's Java
+dependencies for known vulnerabilities. If you are working on addressing dependency vulnerabilities
+in response to a SourceClear finding, you may want to run a scan off of a feature branch and/or local code.
+
+### Github Action
+
+You can trigger TCL's SCA scan on demand via its
+[Github Action](https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/workflows/z-manual-terra-common-lib.yml),
+and optionally specify a Github ref (branch, tag, or SHA) to check out from the repo to scan.  By default,
+the scan is run off of TCL's `develop` branch.
+
+High-level results are outputted in the Github Actions run.
+
+### Running Locally
+
+You will need to get the API token from Vault before running the Gradle `srcclr` task.
+
+```sh
+export SRCCLR_API_TOKEN=$(vault read -field=api_token secret/secops/ci/srcclr/gradle-agent)
+./gradlew srcclr
+```
+
+High-level results are outputted to the terminal.
+
+### Veracode
+
+Full results including dependency graphs are uploaded to
+[Veracode](https://sca.analysiscenter.veracode.com/workspaces/jppForw/projects/544768/issues)
+(if running off of a feature branch, navigate to Project Details > Selected Branch > Change to select your feature branch).
+You can request a Veracode account to view full results from #dsp-infosec-champions.

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,8 @@ dependencies {
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '3.2.3'
 
     // Misc. Services
-    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1-legacy'
+    // PF-3000: k8s client versions 20.0.0 onward without '-legacy' suffix include breaking changes
+    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1-legacy' // keep legacy suffix
     implementation group: 'io.prometheus', name: 'simpleclient_httpserver', version: '0.16.0'
     implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     //     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'org.springframework.boot' version '3.2.3'
     id 'ru.vyarus.quality' version '5.0.0'
+    id 'com.srcclr.gradle' version '3.1.12'
 }
 
 group = gradle.projectGroup
@@ -155,6 +156,7 @@ apply from: "$gradleIncDir/jacoco.gradle"
 apply from: "$gradleIncDir/javadoc.gradle"
 apply from: "$gradleIncDir/publishing.gradle"
 apply from: "$gradleIncDir/quality.gradle"
+apply from: "$gradleIncDir/srcclr.gradle"
 apply from: "$gradleIncDir/sonarqube.gradle"
 apply from: "$gradleIncDir/spotless.gradle"
 apply from: "$gradleIncDir/testing.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -131,11 +131,7 @@ dependencies {
     constraints {
         implementation('org.scala-lang:scala-library:2.13.13')
         implementation('org.json:json:20240205')
-        implementation('org.bitbucket.b_c:jose4j:0.9.5')
         implementation('io.grpc:grpc-xds:1.62.2')
-        // commons-compress comes from io.kubernetes:client-java, which doesn't yet have a version
-        // that pulls in the non-vulnerable version of commons-compress.
-        implementation('org.apache.commons:commons-compress:1.26.0')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '3.2.3'
 
     // Misc. Services
-    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1'
+    implementation group: 'io.kubernetes', name: 'client-java', version: '16.0.0'
     implementation group: 'io.prometheus', name: 'simpleclient_httpserver', version: '0.16.0'
     implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
 
@@ -131,6 +131,7 @@ dependencies {
     constraints {
         implementation('org.scala-lang:scala-library:2.13.13')
         implementation('org.json:json:20240205')
+        implementation('org.bitbucket.b_c:jose4j:0.9.5')
         implementation('io.grpc:grpc-xds:1.62.2')
         // commons-compress comes from io.kubernetes:client-java, which doesn't yet have a version
         // that pulls in the non-vulnerable version of commons-compress.

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '3.2.3'
 
     // Misc. Services
-    implementation group: 'io.kubernetes', name: 'client-java', version: '16.0.0'
+    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1-legacy'
     implementation group: 'io.prometheus', name: 'simpleclient_httpserver', version: '0.16.0'
     implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
 

--- a/gradle/srcclr.gradle
+++ b/gradle/srcclr.gradle
@@ -1,0 +1,3 @@
+srcclr {
+    scope = "runtimeClasspath"
+}

--- a/src/main/java/bio/terra/common/kubernetes/KubePodListener.java
+++ b/src/main/java/bio/terra/common/kubernetes/KubePodListener.java
@@ -159,7 +159,8 @@ class KubePodListener implements Runnable {
   private Watch<V1Namespace> makeWatch(ApiClient apiClient, CoreV1Api kubeApi) throws ApiException {
     return Watch.createWatch(
         apiClient,
-        kubeApi.listNamespacedPod(namespace).limit(5).watch(true).buildCall(null),
+        kubeApi.listNamespacedPodCall(
+            namespace, null, null, null, null, null, 5, null, null, null, Boolean.TRUE, null),
         new TypeToken<Watch.Response<V1Namespace>>() {}.getType());
   }
 

--- a/src/main/java/bio/terra/common/kubernetes/KubePodListener.java
+++ b/src/main/java/bio/terra/common/kubernetes/KubePodListener.java
@@ -160,7 +160,7 @@ class KubePodListener implements Runnable {
     return Watch.createWatch(
         apiClient,
         kubeApi.listNamespacedPodCall(
-            namespace, null, null, null, null, null, 5, null, null, null, Boolean.TRUE, null),
+            namespace, null, null, null, null, null, 5, null, null, null, null, Boolean.TRUE, null),
         new TypeToken<Watch.Response<V1Namespace>>() {}.getType());
   }
 

--- a/src/main/java/bio/terra/common/kubernetes/KubeService.java
+++ b/src/main/java/bio/terra/common/kubernetes/KubeService.java
@@ -101,7 +101,7 @@ public class KubeService {
         CoreV1Api api = makeCoreApi();
         V1PodList list =
             api.listNamespacedPod(
-                namespace, null, null, null, null, null, null, null, null, null, null);
+                namespace, null, null, null, null, null, null, null, null, null, null, null);
         for (V1Pod item : list.getItems()) {
           if (item.getMetadata() != null) {
             String podName = item.getMetadata().getName();

--- a/src/main/java/bio/terra/common/kubernetes/KubeService.java
+++ b/src/main/java/bio/terra/common/kubernetes/KubeService.java
@@ -99,7 +99,9 @@ public class KubeService {
     while (numAttempts <= MAX_RETRY) {
       try {
         CoreV1Api api = makeCoreApi();
-        V1PodList list = api.listNamespacedPod(namespace).execute();
+        V1PodList list =
+            api.listNamespacedPod(
+                namespace, null, null, null, null, null, null, null, null, null, null);
         for (V1Pod item : list.getItems()) {
           if (item.getMetadata() != null) {
             String podName = item.getMetadata().getName();


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PF-3000

**Background**

`terra-common-lib` 1.1.0 upgraded its k8s client from 16.0.0 to 20.0.1 to address a number of security vulnerabilities (note that versions 20.0.0 onward without `-legacy` suffix contained breaking changes): https://github.com/DataBiosphere/terra-common-lib/pull/146

This upgrade appears to have broken [KubePodListener](https://github.com/DataBiosphere/terra-common-lib/blob/e7206005a1c33b4c20065c23bdf188ce12953468/src/main/java/bio/terra/common/kubernetes/KubePodListener.java), which is used by services using [Stairway with pubsub queues](https://broadinstitute.slack.com/archives/C02LMB1PQ6R/p1706809529949099).

The listener exhausts its retries because it can’t [deserialize the Watch response](https://github.com/DataBiosphere/terra-common-lib/blob/e7206005a1c33b4c20065c23bdf188ce12953468/src/main/java/bio/terra/common/kubernetes/KubePodListener.java#L101), and so it never gets to recover flights from deleted pods ([Stackdriver log](https://cloudlogging.app.goo.gl/9YXifWnQzPwRPYa76)).

This is because v20.0.1 includes validation on deserialization that was not previously there, nor present in legacy versions:

v20.0.1 -  https://github.com/kubernetes-client/java/blob/automated-release-20.0.1/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1NamespaceSpec.java

Versus v20.0.1-legacy - https://github.com/kubernetes-client/java/blob/automated-release-20.0.1-legacy/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1NamespaceSpec.java

**Changes**

Version the k8s client at 20.0.1-legacy instead of 20.0.1, in part achieved via a revert of the past upgrade.

By versioning the k8s client at 20.0.1-legacy, we address the same bouncycastle vulnerabilities as the prior non-legacy upgrade without the breaking changes.

Sourceclear has helped me feel confident in the state of this repo's dependency vulnerabilities, and that I've addressed the vulnerabilities I expect without bringing in new ones.  I added Gradle's srcclr plugin and documented how to run scans locally or off of a published feature branch via Github Actions, matching the mechanism and settings that AppSec uses when running these scans.

I've also instructed Dependabot to ignore k8s client upgrades.

**Instructions for Consumers of TCL**

If you haven't already upgraded to TCL 1.1.0+, upgrade TCL as normal.  Do not upgrade k8s client to a non-legacy version.
Otherwise, if your service upgraded k8s client to 20.0.0+ (non-legacy), you will need to revert your upgrade in favor of the legacy version.