### PR TITLE
fix KubePodListener and remove legacy k8s api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,3 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[PF-2983]"
-    ignore:
-      # PF-3000: k8s client versions 20.0.0 onward without '-legacy' suffix include breaking changes
-      - dependency-name: "io.kubernetes:client-java"

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,7 @@ dependencies {
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: '3.2.3'
 
     // Misc. Services
-    // PF-3000: k8s client versions 20.0.0 onward without '-legacy' suffix include breaking changes
-    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1-legacy' // keep legacy suffix
+    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1'
     implementation group: 'io.prometheus', name: 'simpleclient_httpserver', version: '0.16.0'
     implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
 

--- a/src/main/java/bio/terra/common/kubernetes/KubePodListener.java
+++ b/src/main/java/bio/terra/common/kubernetes/KubePodListener.java
@@ -8,8 +8,8 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.Config;
 import io.kubernetes.client.util.Watch;
 import java.io.IOException;
@@ -97,8 +97,8 @@ class KubePodListener implements Runnable {
         final CoreV1Api kubeApi = new CoreV1Api();
 
         // Instantiate the watch and scope it.
-        try (Watch<V1Namespace> watch = makeWatch(client, kubeApi)) {
-          for (Watch.Response<V1Namespace> item : watch) {
+        try (Watch<V1Pod> watch = makeWatch(client, kubeApi)) {
+          for (Watch.Response<V1Pod> item : watch) {
             // If we are shutting down, we stop watching
             if (kubeService.isShutdown()) {
               logger.info("Kubernetes service is shutting down. Exiting.");
@@ -156,12 +156,11 @@ class KubePodListener implements Runnable {
     }
   }
 
-  private Watch<V1Namespace> makeWatch(ApiClient apiClient, CoreV1Api kubeApi) throws ApiException {
+  private Watch<V1Pod> makeWatch(ApiClient apiClient, CoreV1Api kubeApi) throws ApiException {
     return Watch.createWatch(
         apiClient,
-        kubeApi.listNamespacedPodCall(
-            namespace, null, null, null, null, null, 5, null, null, null, null, Boolean.TRUE, null),
-        new TypeToken<Watch.Response<V1Namespace>>() {}.getType());
+        kubeApi.listNamespacedPod(namespace).limit(5).watch(true).buildCall(null),
+        new TypeToken<Watch.Response<V1Pod>>() {}.getType());
   }
 
   private void handleRunningPod(String podName) {

--- a/src/main/java/bio/terra/common/kubernetes/KubeService.java
+++ b/src/main/java/bio/terra/common/kubernetes/KubeService.java
@@ -99,9 +99,7 @@ public class KubeService {
     while (numAttempts <= MAX_RETRY) {
       try {
         CoreV1Api api = makeCoreApi();
-        V1PodList list =
-            api.listNamespacedPod(
-                namespace, null, null, null, null, null, null, null, null, null, null, null);
+        V1PodList list = api.listNamespacedPod(namespace).execute();
         for (V1Pod item : list.getItems()) {
           if (item.getMetadata() != null) {
             String podName = item.getMetadata().getName();


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PF-3000

The problem was that `KubePodListenter` listens for _pods_ but the type the code used was `V1Namespace`. The new java client adds validation and, as one might expected, a response for pods has unexpected fields for a namespace. The correction is to switch from `V1Namespace` to `V1Pod`.