### PR TITLE
[PF-2983] Remove unused protobuf dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     implementation platform('com.google.cloud:libraries-bom:26.33.0')
     implementation group: 'com.google.cloud', name: 'google-cloud-core'
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
-    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.25.3'
     api group: 'com.google.guava', name: 'guava'
 
     // Database


### PR DESCRIPTION
I found no reference to this implementation dependency in TCL.  Because it's not declared as an api dependency, I think we're safe to remove it.

Better to remove rather than spend effort updating it in https://github.com/DataBiosphere/terra-common-lib/pull/171 (or needing to chase future vulnerabilities within an unneeded dependency).