### PR TITLE
[DCJ-457] Register a ThreadPoolTaskExecutor for Stairway as a Bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ build.gradle file (e.g. before `mavenCentral()`.
 
    ```
    # terra-workspace-manager/build.gradle
-   
+
+   // If true, search local repository (~/.m2/repository/) first for dependencies.
+   def useMavenLocal = true
    repositories {
-     mavenLocal()
-     mavenCentral()
-     ...
-   }
+      if (useMavenLocal) {
+          mavenLocal() // must be listed first to take effect
+      }
+      mavenCentral()
+      ...
    ```
 
 That's it! Your service should pick up locally-published changes. If your changes involved bumping 

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 
     // Terra libraries
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-0c4b377'
-    var stairwayVersion= '1.1.1-SNAPSHOT'
+    var stairwayVersion= '1.1.7-SNAPSHOT'
     api "bio.terra:stairway-gcp:${stairwayVersion}"
     implementation "bio.terra:stairway-azure:${stairwayVersion}"
 

--- a/src/main/java/bio/terra/common/stairway/StairwayProperties.java
+++ b/src/main/java/bio/terra/common/stairway/StairwayProperties.java
@@ -1,7 +1,10 @@
 package bio.terra.common.stairway;
 
+import bio.terra.stairway.DefaultThreadPoolTaskExecutor;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /**
  * Properties for configuring a Stairway instance.
@@ -231,5 +234,12 @@ public class StairwayProperties {
 
   public void setAzureQueueEnabled(boolean azureQueueEnabled) {
     this.azureQueueEnabled = azureQueueEnabled;
+  }
+
+  public static final String STAIRWAY_EXECUTOR_BEAN_NAME = "stairwayExecutor";
+
+  @Bean(STAIRWAY_EXECUTOR_BEAN_NAME)
+  public ThreadPoolTaskExecutor stairwayExecutor() {
+    return new DefaultThreadPoolTaskExecutor(maxParallelFlights);
   }
 }

--- a/src/test/java/bio/terra/common/stairway/StairwayComponentTest.java
+++ b/src/test/java/bio/terra/common/stairway/StairwayComponentTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @ExtendWith(MockitoExtension.class)
 class StairwayComponentTest {
@@ -20,6 +21,7 @@ class StairwayComponentTest {
   @Mock private KubeProperties kubeProperties;
   private StairwayProperties stairwayProperties;
   @Mock private KubeService kubeService;
+  @Mock private ThreadPoolTaskExecutor executor;
 
   @Test
   void setupAzureWorkQueueTest() {
@@ -28,7 +30,8 @@ class StairwayComponentTest {
         "Endpoint=sb://azure-xxxx.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=xxxxx";
     setProperties(connectionString, "topicName", "subscriptionName");
 
-    stairwayComponent = new StairwayComponent(kubeService, kubeProperties, stairwayProperties);
+    stairwayComponent =
+        new StairwayComponent(kubeService, kubeProperties, stairwayProperties, executor);
     QueueInterface queue = stairwayComponent.setupAzureWorkQueue();
     assertTrue(queue instanceof AzureServiceBusQueue);
   }
@@ -37,7 +40,8 @@ class StairwayComponentTest {
   void setupAzureWorkQueueTestConnectionStringRequired() {
     setProperties("", "topicName", "subscriptionName");
 
-    stairwayComponent = new StairwayComponent(kubeService, kubeProperties, stairwayProperties);
+    stairwayComponent =
+        new StairwayComponent(kubeService, kubeProperties, stairwayProperties, executor);
     assertThrows(IllegalArgumentException.class, () -> stairwayComponent.setupAzureWorkQueue());
   }
 
@@ -47,7 +51,8 @@ class StairwayComponentTest {
         "Endpoint=sb://azure-xxxx.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=xxxxx";
     setProperties(connectionString, "", "subscriptionName");
 
-    stairwayComponent = new StairwayComponent(kubeService, kubeProperties, stairwayProperties);
+    stairwayComponent =
+        new StairwayComponent(kubeService, kubeProperties, stairwayProperties, executor);
     assertThrows(IllegalArgumentException.class, () -> stairwayComponent.setupAzureWorkQueue());
   }
 
@@ -57,13 +62,15 @@ class StairwayComponentTest {
         "Endpoint=sb://azure-xxxx.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=xxxxx";
     setProperties(connectionString, "topicName", "");
 
-    stairwayComponent = new StairwayComponent(kubeService, kubeProperties, stairwayProperties);
+    stairwayComponent =
+        new StairwayComponent(kubeService, kubeProperties, stairwayProperties, executor);
     assertThrows(IllegalArgumentException.class, () -> stairwayComponent.setupAzureWorkQueue());
   }
 
   @Test
   void setupAzureWorkQueueTestThrowsNPE() {
-    stairwayComponent = new StairwayComponent(kubeService, kubeProperties, stairwayProperties);
+    stairwayComponent =
+        new StairwayComponent(kubeService, kubeProperties, stairwayProperties, executor);
     assertThrows(NullPointerException.class, () -> stairwayComponent.setupAzureWorkQueue());
   }
 

--- a/src/test/java/bio/terra/common/stairway/StairwayPropertiesTest.java
+++ b/src/test/java/bio/terra/common/stairway/StairwayPropertiesTest.java
@@ -1,0 +1,55 @@
+package bio.terra.common.stairway;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.stairway.DefaultThreadPoolTaskExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Tag("unit")
+public class StairwayPropertiesTest {
+
+  private StairwayProperties properties;
+
+  @BeforeEach
+  void beforeEach() {
+    this.properties = new StairwayProperties();
+  }
+
+  @Test
+  void testStairwayProperties_executor_maxParallelFlightsUnspecified() {
+    assertThat(
+        "maxParallelFlights are 0 when unspecified",
+        properties.getMaxParallelFlights(),
+        equalTo(0));
+
+    ThreadPoolTaskExecutor executor = properties.stairwayExecutor();
+    assertThat(executor, instanceOf(DefaultThreadPoolTaskExecutor.class));
+    assertThat(
+        "DefaultThreadPoolTaskExecutor overrides invalid pool size",
+        executor.getMaxPoolSize(),
+        greaterThan(0));
+    assertTrue(executor.isRunning());
+  }
+
+  @Test
+  void testStairwayProperties_executor_maxParallelFlightsSpecified() {
+    int maxParallelFlights = 24;
+    properties.setMaxParallelFlights(maxParallelFlights);
+    assertThat(properties.getMaxParallelFlights(), equalTo(maxParallelFlights));
+
+    ThreadPoolTaskExecutor executor = properties.stairwayExecutor();
+    assertThat(executor, instanceOf(DefaultThreadPoolTaskExecutor.class));
+    assertThat(
+        "DefaultThreadPoolTaskExecutor honors valid pool size",
+        executor.getMaxPoolSize(),
+        equalTo(maxParallelFlights));
+    assertTrue(executor.isRunning());
+  }
+}


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-457

PRs will need to be merged in the following order:
1. https://github.com/DataBiosphere/stairway/pull/149
2. This PR
3. A forthcoming TDR PR to update its TCL version

## Summary of changes

Spring Boot services which leverage TCL to configure its Stairways will now have the backing threadpool automatically instrumented via Spring Boot Actuator and Micrometer.

No additional action is required for calling services to benefit from this change, other than updating their TCL and/or Stairway dependencies to latest.

## Testing Strategy

Expanded unit tests.

Verified end-to-end behavior manually:
- Publishing Stairway and TCL to my local Maven repository
- Booting up TDR, with and without `maxParallelFlights` specified
- Observed that `stairwayExecutor` metrics were automatically flowing through TDR's Actuator endpoint
- Initiated a Stairway flight which succeeded.  Executor occupancy was reflected in actuator metrics.

Example where TDR configured its `maxParallelFlights` to be 120, has one actively running flight, and one completed flight:
```
(base) okotsopo@wm111-e35 jade-data-repo % curl http://localhost:8080/actuator/prometheus | grep 'stairwayExecutor'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 87022  100 8executor_pool_core_threads{name="stairwayExecutor",} 120.0   0
7022    0     0  10.1M      0 --:--:-- --:--:-- --:--:-- 10.3M
executor_queue_remaining_tasks{name="stairwayExecutor",} 2.147483647E9
executor_completed_tasks_total{name="stairwayExecutor",} 1.0
executor_pool_size_threads{name="stairwayExecutor",} 2.0
executor_queued_tasks{name="stairwayExecutor",} 0.0
executor_pool_max_threads{name="stairwayExecutor",} 120.0
executor_active_threads{name="stairwayExecutor",} 1.0
```