### PR TITLE
Bump org.springframework.boot to 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ plugins {
 
     id 'com.diffplug.spotless' version '6.25.0'
     id 'com.github.ben-manes.versions' version '0.51.0'
-    id 'com.jfrog.artifactory' version '5.2.0'
+    id 'com.jfrog.artifactory' version '5.2.2'
     id 'org.sonarqube' version '5.0.0.4638'
-    id 'io.spring.dependency-management' version '1.1.4'
-    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.springframework.boot' version '3.3.1'
     id 'ru.vyarus.quality' version '5.0.0'
     id 'com.srcclr.gradle' version '3.1.12'
 }
@@ -67,7 +67,7 @@ dependencies {
 
     // Google dependencies
     // use common bom
-    implementation platform('com.google.cloud:libraries-bom:26.38.0')
+    implementation platform('com.google.cloud:libraries-bom:26.42.0')
     implementation group: 'com.google.cloud', name: 'google-cloud-core'
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
     api group: 'com.google.guava', name: 'guava'
@@ -107,8 +107,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-autoconfigure'
 
     // Google cloud open telemetry exporters
-    implementation 'com.google.cloud.opentelemetry:exporter-trace:0.28.0'
-    implementation 'com.google.cloud.opentelemetry:exporter-metrics:0.28.0'
+    implementation 'com.google.cloud.opentelemetry:exporter-trace:0.31.0'
+    implementation 'com.google.cloud.opentelemetry:exporter-metrics:0.31.0'
 
     // Testing
     testImplementation 'org.springframework:spring-aspects' // for tracing in tests


### PR DESCRIPTION
- Bump org.springframework.boot to 3.3.1 - this bumps the transitive dependency org.apache.tomcat.embed:tomcat-embed-core to 10.1.25 to fix a security vulnerability
- Making the change in this library, since this is included in https://github.com/DataBiosphere/tanagra
- other changes - bump other libraries (patch / minor versions only)