### PR TITLE
PF-2983: bump artifactory, sonarqube, bcprov-jdk18on, google cloud bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
     id 'com.diffplug.spotless' version '6.25.0'
     id 'com.github.ben-manes.versions' version '0.51.0'
-    id 'com.jfrog.artifactory' version '5.2.2'
-    id 'org.sonarqube' version '5.0.0.4638'
+    id 'com.jfrog.artifactory' version '5.2.3'
+    id 'org.sonarqube' version '5.1.0.4882'
     id 'io.spring.dependency-management' version '1.1.5'
     id 'org.springframework.boot' version '3.3.1'
     id 'ru.vyarus.quality' version '5.0.0'
@@ -58,7 +58,7 @@ dependencies {
     // Misc. Services
     implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1'
     constraints {
-        implementation('org.bouncycastle:bcprov-jdk18on:1.78') {
+        implementation('org.bouncycastle:bcprov-jdk18on:1.78.1') {
             because 'https://broadworkbench.atlassian.net/browse/DCJ-275'
         }
     }
@@ -67,7 +67,7 @@ dependencies {
 
     // Google dependencies
     // use common bom
-    implementation platform('com.google.cloud:libraries-bom:26.42.0')
+    implementation platform('com.google.cloud:libraries-bom:26.44.0')
     implementation group: 'com.google.cloud', name: 'google-cloud-core'
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
     api group: 'com.google.guava', name: 'guava'


### PR DESCRIPTION
Unbundle some of the dependency updates from Dependabot's #193.

That other PR is hitting build issues. This PR attempts to tackle the (hopefully) easy dependency updates so we can make incremental progress.