### PR TITLE
[PF-3006] Manually migrate to 2.6.0 version of open telemetry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ project.ext {
 
 // Spring Boot 3.2.3 pulls in opentelemetry-bom 1.31.0.
 // We need >= 1.32.0 so that our HttpServerMetrics can use Meter.setExplicitBucketBoundariesAdvice:
-ext['opentelemetry.version'] = '1.37.0'
+ext['opentelemetry.version'] = '1.40.0'
 
 // If true, search local repository (~/.m2/repository/) first for dependencies.
 def useMavenLocal = false

--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,8 @@ dependencies {
 
     // OpenTelemetry BOMs (opentelemetry-bom versioned by Spring dependency manager)
     implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.37.0-alpha')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.3.0')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.3.0-alpha')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.6.0')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.6.0-alpha')
     // OpenTelemetry dependencies versioned by BOMs
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-sdk'
@@ -99,7 +99,7 @@ dependencies {
     implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-6.0'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-autoconfigure'
     implementation 'io.opentelemetry:opentelemetry-exporter-prometheus'
     implementation 'io.opentelemetry:opentelemetry-api-incubator'
     implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'

--- a/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
+++ b/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
@@ -1,7 +1,6 @@
 package bio.terra.common.opentelemetry;
 
 import bio.terra.common.tracing.ExcludingUrlSampler;
-import io.opentelemetry.instrumentation.spring.autoconfigure.EnableOpenTelemetry;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.View;
@@ -17,7 +16,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.util.Pair;
 
 @Configuration
-@EnableOpenTelemetry
 @EnableConfigurationProperties(value = {TracingProperties.class})
 public class OpenTelemetryConfig {
 


### PR DESCRIPTION
Note: `io.opentelemetry.instrumentation.spring.autoconfigure.EnableOpenTelemetry` was removed in this version but presumably should not be needed.  May be worth checking if this continues to work (not entirely sure how to test that)