### PR TITLE
[WOR-1744] Restore MetricReader registration in OpenTelemetryConfig

### DIFF
--- a/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
+++ b/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
@@ -5,6 +5,7 @@ import io.opentelemetry.instrumentation.spring.autoconfigure.EnableOpenTelemetry
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Map;
@@ -28,6 +29,7 @@ public class OpenTelemetryConfig {
   public AutoConfigurationCustomizerProvider otelCustomizer(
       TracingProperties tracingProperties,
       ObjectProvider<Pair<InstrumentSelector, View>> views,
+      ObjectProvider<MetricReader> metricReaders,
       ObjectProvider<SpanProcessor> spanProcessors) {
     return customizer -> {
       // the default exporter is the OTLP exporter, which we don't use and outputs errors like:
@@ -38,6 +40,7 @@ public class OpenTelemetryConfig {
 
       customizer.addMeterProviderCustomizer(
           (builder, unused) -> {
+            metricReaders.stream().forEach(builder::registerMetricReader);
             views.stream().forEach(pair -> builder.registerView(pair.getFirst(), pair.getSecond()));
             return builder;
           });


### PR DESCRIPTION
Ticket: [WOR-1744](https://broadworkbench.atlassian.net/browse/WOR-1744)
* During a recent dependency upgrade, we had to refactor the OpenTelemetryConfig. During the refactor, we [missed the registration of MetricReaders that we had before](https://github.com/DataBiosphere/terra-common-lib/pull/178/files#diff-11431a6513b4469762bdd28cd565339c6f00fab038ea51d2f02a24500b2e5b60L40). I've tested this locally with RBS and seen that metrics are once again surfaced at the `/metrics` Prometheus endpoint.

[WOR-1744]: https://broadworkbench.atlassian.net/browse/WOR-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ