### PR TITLE
PF-2983: Bump io.kubernetes:client-java from 20.0.1 to 21.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
 
     // Misc. Services
-    implementation group: 'io.kubernetes', name: 'client-java', version: '20.0.1'
+    implementation group: 'io.kubernetes', name: 'client-java', version: '21.0.1'
     constraints {
         implementation('org.bouncycastle:bcprov-jdk18on:1.78.1') {
             because 'https://broadworkbench.atlassian.net/browse/DCJ-275'

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
 
     // Misc. Services
-    implementation group: 'io.kubernetes', name: 'client-java', version: '21.0.1'
+    implementation group: 'io.kubernetes', name: 'client-java', version: '21.0.2'
     constraints {
         implementation('org.bouncycastle:bcprov-jdk18on:1.78.1') {
             because 'https://broadworkbench.atlassian.net/browse/DCJ-275'


### PR DESCRIPTION
manual fix to a dependabot PR; supersedes #202. This PR uses the non-legacy version of the client `21.0.2` instead of the (incompatible) legacy version `21.0.1-legacy`.