### PR TITLE
CORE-69: minor patch deps no spring boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'com.jfrog.artifactory' version '5.2.5'
     id 'org.sonarqube' version '5.1.0.4882'
     id 'io.spring.dependency-management' version '1.1.6'
-    id 'org.springframework.boot' version '3.3.5'
+    id 'org.springframework.boot' version '3.3.4'
     id 'ru.vyarus.quality' version '5.0.0'
     id 'com.srcclr.gradle' version '3.1.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'com.jfrog.artifactory' version '5.2.5'
     id 'org.sonarqube' version '5.1.0.4882'
     id 'io.spring.dependency-management' version '1.1.6'
-    id 'org.springframework.boot' version '3.3.4'
+    id 'org.springframework.boot' version '3.3.5'
     id 'ru.vyarus.quality' version '5.0.0'
     id 'com.srcclr.gradle' version '3.1.12'
 }
@@ -58,7 +58,7 @@ dependencies {
     // Misc. Services
     implementation group: 'io.kubernetes', name: 'client-java', version: '21.0.2'
     constraints {
-        implementation('org.bouncycastle:bcprov-jdk18on:1.78.1') {
+        implementation('org.bouncycastle:bcprov-jdk18on:1.79') {
             because 'https://broadworkbench.atlassian.net/browse/DCJ-275'
         }
     }
@@ -67,7 +67,7 @@ dependencies {
 
     // Google dependencies
     // use common bom
-    implementation platform('com.google.cloud:libraries-bom:26.47.0')
+    implementation platform('com.google.cloud:libraries-bom:26.50.0')
     implementation group: 'com.google.cloud', name: 'google-cloud-core'
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub'
     api group: 'com.google.guava', name: 'guava'
@@ -78,7 +78,7 @@ dependencies {
 
     // Terra libraries
     implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-0c4b377'
-    var stairwayVersion= '1.1.13-SNAPSHOT'
+    var stairwayVersion= '1.1.15-SNAPSHOT'
     api "bio.terra:stairway-gcp:${stairwayVersion}"
     implementation "bio.terra:stairway-azure:${stairwayVersion}"
 
@@ -89,9 +89,9 @@ dependencies {
 
     // OpenTelemetry BOMs (opentelemetry-bom versioned by Spring dependency manager)
     // If the following versions get updated, be sure to update line 25 for ext['opentelemetry.version']
-    implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.42.1-alpha')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.8.0')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.8.0-alpha')
+    implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.44.1-alpha')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.10.0')
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.10.0-alpha')
     // OpenTelemetry dependencies versioned by BOMs
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-sdk'
@@ -108,8 +108,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-autoconfigure'
 
     // Google cloud open telemetry exporters
-    implementation 'com.google.cloud.opentelemetry:exporter-trace:0.32.0'
-    implementation 'com.google.cloud.opentelemetry:exporter-metrics:0.32.0'
+    implementation 'com.google.cloud.opentelemetry:exporter-trace:0.33.0'
+    implementation 'com.google.cloud.opentelemetry:exporter-metrics:0.33.0'
 
     // Testing
     testImplementation 'org.springframework:spring-aspects' // for tracing in tests


### PR DESCRIPTION
A branch off of #206 that includes all its updates _except_ the Spring Boot update.

Description copied from #206, with Spring Boot and mention of Dependabot commands removed:

---

Bumps the minor-patch-dependencies group with 9 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [org.bouncycastle:bcprov-jdk18on](https://github.com/bcgit/bc-java) | `1.78.1` | `1.79` |
| [com.google.cloud:libraries-bom](https://github.com/googleapis/java-cloud-bom) | `26.47.0` | `26.50.0` |
| bio.terra:stairway-gcp | `1.1.13-SNAPSHOT` | `1.1.15-SNAPSHOT` |
| bio.terra:stairway-azure | `1.1.13-SNAPSHOT` | `1.1.15-SNAPSHOT` |
| [io.opentelemetry:opentelemetry-bom-alpha](https://github.com/open-telemetry/opentelemetry-java) | `1.42.1-alpha` | `1.44.1-alpha` |
| [io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom](https://github.com/open-telemetry/opentelemetry-java-instrumentation) | `2.8.0` | `2.10.0` |
| [com.google.cloud.opentelemetry:exporter-trace](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java) | `0.32.0` | `0.33.0` |
| [com.google.cloud.opentelemetry:exporter-metrics](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java) | `0.32.0` | `0.33.0` |


Updates `org.bouncycastle:bcprov-jdk18on` from 1.78.1 to 1.79
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html">org.bouncycastle:bcprov-jdk18on's changelog</a>.</em></p>
<blockquote>
<!-- raw HTML omitted -->
<!-- raw HTML omitted -->
<!-- raw HTML omitted -->
<p><!-- raw HTML omitted --><!-- raw HTML omitted -->2.1.1 Version<!-- raw HTML omitted --><!-- raw HTML omitted -->
Release: 1.80<!-- raw HTML omitted -->
Date:      TBD.</p>
<!-- raw HTML omitted -->
<p><!-- raw HTML omitted --><!-- raw HTML omitted -->2.2.1 Version<!-- raw HTML omitted --><!-- raw HTML omitted -->
Release: 1.79<!-- raw HTML omitted -->
Date:      2024, 30th October.</p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/bcgit/bc-java/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `com.google.cloud:libraries-bom` from 26.47.0 to 26.50.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/googleapis/java-cloud-bom/releases">com.google.cloud:libraries-bom's releases</a>.</em></p>
<blockquote>
<h2>v26.50.0</h2>
<p>GCP Libraries BOM 26.50.0</p>
<p>Here are the differences from the previous version (26.49.0)</p>
<p>The group ID of the following artifacts is <code>com.google.cloud</code>.</p>
<h1>Notable Changes</h1>
<h2>Protobuf-Java v4.28.3</h2>
<p>This version of Libraries-Bom is upgrading the Protobuf Java (PBJ) Runtime version to v4.28.3. The Java SDK aims to use the latest Protobuf version to utilize the latest stable features and to mitigate vulnerabilities (CVEs).</p>
<h3>Potential PBJ Runtime 4.28.3 Upgrade Issues</h3>
<p>There are a few potential compatibility issues that <em>may</em> arise for users following the PBJ Runtime upgrade to v4.28.3. Details about these potential issues are outlined below.</p>
<p>Note: The following issues may not be exhaustive and users may encounter additional issues.</p>
<h4>Source Compatibility Issues</h4>
<p>PBJ 4.26.x removed some methods from runtime. Users may see source compilation issues when compiling their application. If you do not use any of the following removed methods, you should not see these issues.</p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/23ace8b9841c238a5db4171d04656947007423d1"><code>23ace8b</code></a> chore: release main (<a href="https://redirect.github.com/googleapis/java-cloud-bom/issues/6817">#6817</a>)</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/88b0c809fbae4ec42cd8f3a204c4e8c4264e64b3"><code>88b0c80</code></a> deps: update dependency com.google.cloud:google-cloud-pubsublite-bom to v1.14...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/5662b26ffb3664251d548f1426389205f972496f"><code>5662b26</code></a> chore: Override the version of protobuf-bom to 4.28.3 in libraries-bom. (<a href="https://redirect.github.com/googleapis/java-cloud-bom/issues/6836">#6836</a>)</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/2c49bcfe0a415e8255a7c9b3cc94951177a1da92"><code>2c49bcf</code></a> deps: update dependency com.google.cloud:google-cloud-nio to v0.127.26 (<a href="https://redirect.github.com/googleapis/java-cloud-bom/issues/6835">#6835</a>)</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/9cc59baf594b47ea7737a75ff1ea9f53a93ce2c7"><code>9cc59ba</code></a> deps: update dependency com.google.cloud:google-cloud-bigtable-bom to v2.46.0...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/2d2b829aa741fa7b13c894cbfc89e92b80267489"><code>2d2b829</code></a> deps: update dependency com.google.cloud:google-cloud-firestore-bom to v3.28....</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/39c5c2f2328776ce12ede33a86e7279a6d252fa5"><code>39c5c2f</code></a> deps: update dependency com.google.cloud:google-cloud-bigquerystorage-bom to ...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/476cc06f117d7967cb079f4e591983d512da61f1"><code>476cc06</code></a> deps: update dependency com.google.cloud:google-cloud-logging-logback to v0.1...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/d02b9b5e6ceb6ab46d93716800180f0695fa0ee6"><code>d02b9b5</code></a> deps: update dependency com.google.cloud:google-cloud-pubsub-bom to v1.134.1 ...</li>
<li><a href="https://github.com/googleapis/java-cloud-bom/commit/04012696b2e7ef516e39bcd5c5fb0005b6ace817"><code>0401269</code></a> deps: update dependency com.google.cloud:google-cloud-spanner-bom to v6.80.1 ...</li>
<li>Additional commits viewable in <a href="https://github.com/googleapis/java-cloud-bom/compare/v26.47.0...v26.50.0">compare view</a></li>
</ul>
</details>
<br />

Updates `bio.terra:stairway-gcp` from 1.1.13-SNAPSHOT to 1.1.15-SNAPSHOT

Updates `bio.terra:stairway-azure` from 1.1.13-SNAPSHOT to 1.1.15-SNAPSHOT

Updates `bio.terra:stairway-azure` from 1.1.13-SNAPSHOT to 1.1.15-SNAPSHOT

Updates `io.opentelemetry:opentelemetry-bom-alpha` from 1.42.1-alpha to 1.44.1-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java/releases">io.opentelemetry:opentelemetry-bom-alpha's releases</a>.</em></p>
<blockquote>
<h2>Version 1.44.0</h2>
<h3>API</h3>
<ul>
<li>Fix ConfigUtil#getString ConcurrentModificationException (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6841">#6841</a>)</li>
</ul>
<h3>SDK</h3>
<h4>Traces</h4>
<ul>
<li>Stabilize ExceptionEventData (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6795">#6795</a>)</li>
</ul>
<h4>Metrics</h4>
<ul>
<li>Stabilize metric cardinality limits (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6794">#6794</a>)</li>
<li>Refactor metrics internals to remove MeterSharedState (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6845">#6845</a>)</li>
</ul>
<h4>Exporters</h4>
<ul>
<li>Add memory mode option to stdout exporters (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6774">#6774</a>)</li>
<li>Log a warning if OTLP endpoint port is likely incorrect given the protocol (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6813">#6813</a>)</li>
<li>Fix OTLP gRPC retry mechanism for unsuccessful HTTP responses (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6829">#6829</a>)</li>
<li>Add ByteBuffer field type marshaling support (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6686">#6686</a>)</li>
<li>Fix stdout exporter format by adding newline after each export (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6848">#6848</a>)</li>
<li>Enable <code>reusuable_data</code> memory mode by default for <code>OtlpGrpc{Signal}Exporter</code>, <code>OtlpHttp{Signal}Exporter</code>, <code>OtlpStdout{Signal}Exporter</code>, and <code>PrometheusHttpServer</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6799">#6799</a>)</li>
</ul>
<h4>Extension</h4>
<ul>
<li>Rebrand file configuration to declarative configuration in documentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6812">#6812</a>)</li>
<li>Fix declarative config <code>file_format</code> validation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6786">#6786</a>)</li>
<li>Fix declarative config env substitution by disallowing '}' in default value (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6793">#6793</a>)</li>
<li>Set declarative config default OTLP protocol to http/protobuf (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6800">#6800</a>)</li>
<li>Stabilize autoconfigure disabling of resource keys via <code>otel.resource.disabled.keys</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6809">#6809</a>)</li>
</ul>
<h3>Tooling</h3>
<ul>
<li>Run tests on Java 23 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6825">#6825</a>)</li>
<li>Test Windows in CI (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6824">#6824</a>)</li>
<li>Add error prone checks for internal javadoc and private constructors (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6844">#6844</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/cyrille-leclerc"><code>@​cyrille-leclerc</code></a>
<a href="https://github.com/hboutemy"><code>@​hboutemy</code></a>
<a href="https://github.com/jack-berg"><code>@​jack-berg</code></a>
<a href="https://github.com/jaydeluca"><code>@​jaydeluca</code></a>
<a href="https://github.com/jhalliday"><code>@​jhalliday</code></a>
<a href="https://github.com/JiwonKKang"><code>@​JiwonKKang</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java/blob/main/CHANGELOG.md">io.opentelemetry:opentelemetry-bom-alpha's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 1.44.1 (2024-11-10)</h2>
<h3>SDK</h3>
<h4>Traces</h4>
<ul>
<li>Fix regression in event attributes
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6865">#6865</a>)</li>
</ul>
<h2>Version 1.44.0 (2024-11-08)</h2>
<h3>API</h3>
<ul>
<li>Fix ConfigUtil#getString ConcurrentModificationException
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6841">#6841</a>)</li>
</ul>
<h3>SDK</h3>
<h4>Traces</h4>
<ul>
<li>Stabilize ExceptionEventData
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6795">#6795</a>)</li>
</ul>
<h4>Metrics</h4>
<ul>
<li>Stabilize metric cardinality limits
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6794">#6794</a>)</li>
<li>Refactor metrics internals to remove MeterSharedState
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6845">#6845</a>)</li>
</ul>
<h4>Exporters</h4>
<ul>
<li>Add memory mode option to stdout exporters
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6774">#6774</a>)</li>
<li>Log a warning if OTLP endpoint port is likely incorrect given the protocol
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6813">#6813</a>)</li>
<li>Fix OTLP gRPC retry mechanism for unsuccessful HTTP responses
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6829">#6829</a>)</li>
<li>Add ByteBuffer field type marshaling support
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6686">#6686</a>)</li>
<li>Fix stdout exporter format by adding newline after each export
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6848">#6848</a>)</li>
<li>Enable <code>reusuable_data</code> memory mode by default for <code>OtlpGrpc{Signal}Exporter</code>,
<code>OtlpHttp{Signal}Exporter</code>, <code>OtlpStdout{Signal}Exporter</code>, and <code>PrometheusHttpServer</code>
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6799">#6799</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/opentelemetry-java/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom` from 2.8.0 to 2.10.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases">io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom's releases</a>.</em></p>
<blockquote>
<h2>Version 2.10.0</h2>
<p>This release targets the OpenTelemetry SDK 1.44.1.</p>
<p>Note that many artifacts have the <code>-alpha</code> suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning">VERSIONING.md</a> for more details.</p>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>Ktor 3 instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12562">#12562</a>)</li>
</ul>
<h3>🌟 New library instrumentation</h3>
<ul>
<li>Ktor 3 instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12562">#12562</a>)</li>
</ul>
<h3>Migration notes</h3>
<ul>
<li>Spring Boot Starter Scheduling instrumentation scope name changed from <code>io.opentelemetry.spring-scheduling-3.1</code> to <code>io.opentelemetry.spring-boot-autoconfigure</code> to reflect the module's name.</li>
<li>Default flush timeout for aws lambda javaagent instrumentation changed from 1 second to 10 seconds to match the flush timeout used in the aws lambda library instrumentation. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12576">#12576</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Delegate loading of java package to platform loader (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12505">#12505</a>)</li>
<li>Set up virtual field transforms before otel sdk is initialized (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12444">#12444</a>)</li>
<li>Update azure-core-tracing-opentelemetry version and improve HTTP suppression to back off when Azure SDK tracing is disabled. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12489">#12489</a>)</li>
<li>Ktor2 http client uses low level instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12530">#12530</a>)</li>
<li>Add logback mdc instrumentation to spring boot starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12515">#12515</a>)</li>
<li>Run class load listener only once (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12565">#12565</a>)</li>
<li>Remove duplicate byte buddy classes to reduce agent jar file size (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12571">#12571</a>)</li>
<li>Support additional JVM arg syntax in service name resource detector (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12544">#12544</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Fix derby directory connection string parser (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12479">#12479</a>)</li>
<li>Improve whitespace handling in oracle jdbc url parser (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12512">#12512</a>)</li>
<li>Fix SpanKey bridging for unbridgeable span (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12511">#12511</a>)</li>
<li>Fix lettuce instrumentation and tests to pass against latest version (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12552">#12552</a>)</li>
<li>Fix Kafka initialization occasionally failed due to concurrent injection of OpenTelemetryMetricsReporter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12583">#12583</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/AntonioLyubchev"><code>@​AntonioLyubchev</code></a>
<a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/brunobat"><code>@​brunobat</code></a>
<a href="https://github.com/Cirilla-zmh"><code>@​Cirilla-zmh</code></a>
<a href="https://github.com/e5l"><code>@​e5l</code></a>
<a href="https://github.com/greatvovan"><code>@​greatvovan</code></a>
<a href="https://github.com/heyams"><code>@​heyams</code></a>
<a href="https://github.com/jaydeluca"><code>@​jaydeluca</code></a>
<a href="https://github.com/jeanbisutti"><code>@​jeanbisutti</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md">io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom's changelog</a>.</em></p>
<blockquote>
<h2>Version 2.10.0 (2024-11-13)</h2>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>Ktor 3 instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12562">#12562</a>)</li>
</ul>
<h3>🌟 New library instrumentation</h3>
<ul>
<li>Ktor 3 instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12562">#12562</a>)</li>
</ul>
<h3>Migration notes</h3>
<ul>
<li>Spring Boot Starter Scheduling instrumentation scope name changed from
<code>io.opentelemetry.spring-scheduling-3.1</code> to <code>io.opentelemetry.spring-boot-autoconfigure</code>
to reflect the module's name.</li>
<li>Default flush timeout for aws lambda javaagent instrumentation changed from 1 second
to 10 seconds to match the flush timeout used in the aws lambda library instrumentation.
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12576">#12576</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Delegate loading of java package to platform loader
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12505">#12505</a>)</li>
<li>Set up virtual field transforms before otel sdk is initialized
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12444">#12444</a>)</li>
<li>Update azure-core-tracing-opentelemetry version and improve HTTP suppression to back off
when Azure SDK tracing is disabled.
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12489">#12489</a>)</li>
<li>Ktor2 http client uses low level instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12530">#12530</a>)</li>
<li>Add logback mdc instrumentation to spring boot starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12515">#12515</a>)</li>
<li>Run class load listener only once
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12565">#12565</a>)</li>
<li>Remove duplicate byte buddy classes to reduce agent jar file size
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12571">#12571</a>)</li>
<li>Support additional JVM arg syntax in service name resource detector
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12544">#12544</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Fix derby directory connection string parser
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12479">#12479</a>)</li>
<li>Improve whitespace handling in oracle jdbc url parser
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12512">#12512</a>)</li>
<li>Fix SpanKey bridging for unbridgeable span
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12511">#12511</a>)</li>
<li>Fix lettuce instrumentation and tests to pass against latest version</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/0ca120d1b5e66dec6c5d2637fbb8c70b337718f8"><code>0ca120d</code></a> [release/v2.10.x] Prepare release 2.10.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12620">#12620</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/cd65f9aa883070934f81b9821c91f8c80c409a0f"><code>cd65f9a</code></a> Update change log for upcoming release (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12607">#12607</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/3d5492184fee622a27c170eafa9bea48920890ce"><code>3d54921</code></a> Convert rediscala test to scala (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12616">#12616</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/647fc45914725b4805f63b97c0084f951397c774"><code>647fc45</code></a> fix(deps): update dependency io.netty:netty-bom to v4.1.115.final (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12618">#12618</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/ad21efb378ede3efdd9ae8d4a0da34ef15eaec75"><code>ad21efb</code></a> Convert aws 1.11 client tests from groovy to java (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12606">#12606</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/76c2d2d8f335f9f946316a98e442d6191a66709e"><code>76c2d2d</code></a> Add ktor 3 instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12562">#12562</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/fdfb764c76e5fd357bfd8a9d610606c554cc1d4b"><code>fdfb764</code></a> chore(deps): update github/codeql-action action to v3.27.1 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12610">#12610</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/74d07f1d36343ff05ebe2b25da92765f8bd9bf0c"><code>74d07f1</code></a> Database stable semconv tests and fixes (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12601">#12601</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/591cdf5c79ec44a7e37b22d1610e5623bc3d2d93"><code>591cdf5</code></a> Move get attribute inside condition where used (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12604">#12604</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/0e099b281baaf3ad146b81543e9226294661bdaf"><code>0e099b2</code></a> Update the OpenTelemetry SDK version to 1.44.1 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12603">#12603</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/compare/v2.8.0...v2.10.0">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha` from 2.8.0-alpha to 2.10.0-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases">io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha's releases</a>.</em></p>
<blockquote>
<h2>Version 2.9.0</h2>
<p>This release targets the OpenTelemetry SDK 1.43.0.</p>
<p>Note that many artifacts have the <code>-alpha</code> suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning">VERSIONING.md</a> for more details.</p>
<h3>📈 Enhancements</h3>
<ul>
<li>Allow JMX Insight reuse for remote connections (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12178">#12178</a>)</li>
<li>Add opentelemetry-semconv-incubating to bom-alpha (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12266">#12266</a>)</li>
<li>Bridge more incubating api (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12230">#12230</a>)</li>
<li>Jetty HttpClient 12: propagate context to all response listeners (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12326">#12326</a>)</li>
<li>Add Pekko Scheduler context propagation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12359">#12359</a>)</li>
<li>Add Akka Scheduler context propagation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12373">#12373</a>)</li>
<li>Add instrumentation for spring-cloud-aws SqsListener annotation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12314">#12314</a>)</li>
<li>Align SpringConfigProperties with DefaultConfigProperties (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12398">#12398</a>)</li>
<li>Clear context propagation virtual field (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12397">#12397</a>)</li>
<li>The opt-in experimental attribute <code>aws.requestId</code> was renamed to <code>aws.request_id</code> (to match the semantic conventions) and it is now emitted by default. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12352">#12352</a>)</li>
<li>Ability to set Logback argument capture with a property in Spring Boot Starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12442">#12442</a>)</li>
<li>Support experimental declarative configuration (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12265">#12265</a>)</li>
<li>Spring Boot Starter: Add auto configuration for spring scheduling instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12438">#12438</a>)</li>
<li>Extract <code>APIGatewayProxyRequestEvent</code> headers for context propagation in AWS Lambda instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12440">#12440</a>)</li>
<li>Support JMX state metrics (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12369">#12369</a>)</li>
<li>Allow method instrumentation module to trace methods in boot loader (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12454">#12454</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Fix gc duration metric in runtime-telemetry-java17 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12256">#12256</a>)</li>
<li>Fix vert.x route containing duplicate segments when RoutingContext.next is used (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12260">#12260</a>)</li>
<li>Fixes for latest mongo version (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12331">#12331</a>)</li>
<li>Fix context propagation for ratpack request body stream (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12330">#12330</a>)</li>
<li>Fix lambda instrumentation to forceFlush logs also (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12341">#12341</a>)</li>
<li>Can't add custom AttributeExtractor to Apache HttpClient 5 library instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12394">#12394</a>)</li>
<li>Disable logback capture arguments by default (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12445">#12445</a>)</li>
<li>Add support for missing list properties in spring starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12434">#12434</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/aarrsseni"><code>@​aarrsseni</code></a>
<a href="https://github.com/AntonioLyubchev"><code>@​AntonioLyubchev</code></a>
<a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/brunobat"><code>@​brunobat</code></a>
<a href="https://github.com/cleverchuk"><code>@​cleverchuk</code></a>
<a href="https://github.com/Dimagreg"><code>@​Dimagreg</code></a>
<a href="https://github.com/dubek"><code>@​dubek</code></a>
<a href="https://github.com/egahlin"><code>@​egahlin</code></a>
<a href="https://github.com/encodedrose"><code>@​encodedrose</code></a>
<a href="https://github.com/fabiolnh"><code>@​fabiolnh</code></a>
<a href="https://github.com/heyams"><code>@​heyams</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md">io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 2.10.0 (2024-11-13)</h2>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>Ktor 3 instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12562">#12562</a>)</li>
</ul>
<h3>🌟 New library instrumentation</h3>
<ul>
<li>Ktor 3 instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12562">#12562</a>)</li>
</ul>
<h3>Migration notes</h3>
<ul>
<li>Spring Boot Starter Scheduling instrumentation scope name changed from
<code>io.opentelemetry.spring-scheduling-3.1</code> to <code>io.opentelemetry.spring-boot-autoconfigure</code>
to reflect the module's name.</li>
<li>Default flush timeout for aws lambda javaagent instrumentation changed from 1 second
to 10 seconds to match the flush timeout used in the aws lambda library instrumentation.
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12576">#12576</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Delegate loading of java package to platform loader
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12505">#12505</a>)</li>
<li>Set up virtual field transforms before otel sdk is initialized
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12444">#12444</a>)</li>
<li>Update azure-core-tracing-opentelemetry version and improve HTTP suppression to back off
when Azure SDK tracing is disabled.
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12489">#12489</a>)</li>
<li>Ktor2 http client uses low level instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12530">#12530</a>)</li>
<li>Add logback mdc instrumentation to spring boot starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12515">#12515</a>)</li>
<li>Run class load listener only once
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12565">#12565</a>)</li>
<li>Remove duplicate byte buddy classes to reduce agent jar file size
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12571">#12571</a>)</li>
<li>Support additional JVM arg syntax in service name resource detector
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12544">#12544</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Fix derby directory connection string parser
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/12479">#12479</a>)</li>
<li>Improve whitespace handling in oracle jdbc url parser</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `com.google.cloud.opentelemetry:exporter-trace` from 0.32.0 to 0.33.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/releases">com.google.cloud.opentelemetry:exporter-trace's releases</a>.</em></p>
<blockquote>
<h2>v0.33.0</h2>
<h2>Release Highlights</h2>
<ul>
<li>Update the OpenTelemetry and Google library dependencies to address a reported CVE.</li>
</ul>
<h2>What's Changed</h2>
<ul>
<li>Update RELEASING.md by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/375">GoogleCloudPlatform/opentelemetry-operations-java#375</a></li>
<li>Add links to quickstart and observability overview to README by <a href="https://github.com/aabmass"><code>@​aabmass</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/378">GoogleCloudPlatform/opentelemetry-operations-java#378</a></li>
<li>Add otlp metrics export from Google Cloud Run Functions by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/377">GoogleCloudPlatform/opentelemetry-operations-java#377</a></li>
<li>Update collector image by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/380">GoogleCloudPlatform/opentelemetry-operations-java#380</a></li>
<li>Mention that newer Log4j2 versions do not need additional fields by <a href="https://github.com/aabmass"><code>@​aabmass</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/379">GoogleCloudPlatform/opentelemetry-operations-java#379</a></li>
<li>Update dependencies by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/381">GoogleCloudPlatform/opentelemetry-operations-java#381</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/compare/v0.32.0...v0.33.0">https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/compare/v0.32.0...v0.33.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/6455156e9d97eb882f9cca020387ad3cdb525b2e"><code>6455156</code></a> Update dependencies (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/381">#381</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/6301056ea20b30b341b8e16b09c6d1dd2cfe1b7b"><code>6301056</code></a> Mention that newer Log4j2 versions do not need additional fields (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/379">#379</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/9c7510b21512c3d1693041d60a1a483b5db51f93"><code>9c7510b</code></a> Update collector image (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/380">#380</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/4181e2d07a15e056458f9c0a06304f5f5b08aa27"><code>4181e2d</code></a> Add otlp metrics export from Google Cloud Run Functions (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/377">#377</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/ff4949ec1a37057cd3bc5db786d95dc420ee58cd"><code>ff4949e</code></a> Add links to quickstart and observability overview to README (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/378">#378</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/371d1cde1745311f30704ea54640728c4d48d6de"><code>371d1cd</code></a> Update RELEASING.md (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/375">#375</a>)</li>
<li>See full diff in <a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/compare/v0.32.0...v0.33.0">compare view</a></li>
</ul>
</details>
<br />

Updates `com.google.cloud.opentelemetry:exporter-metrics` from 0.32.0 to 0.33.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/releases">com.google.cloud.opentelemetry:exporter-metrics's releases</a>.</em></p>
<blockquote>
<h2>v0.33.0</h2>
<h2>Release Highlights</h2>
<ul>
<li>Update the OpenTelemetry and Google library dependencies to address a reported CVE.</li>
</ul>
<h2>What's Changed</h2>
<ul>
<li>Update RELEASING.md by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/375">GoogleCloudPlatform/opentelemetry-operations-java#375</a></li>
<li>Add links to quickstart and observability overview to README by <a href="https://github.com/aabmass"><code>@​aabmass</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/378">GoogleCloudPlatform/opentelemetry-operations-java#378</a></li>
<li>Add otlp metrics export from Google Cloud Run Functions by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/377">GoogleCloudPlatform/opentelemetry-operations-java#377</a></li>
<li>Update collector image by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/380">GoogleCloudPlatform/opentelemetry-operations-java#380</a></li>
<li>Mention that newer Log4j2 versions do not need additional fields by <a href="https://github.com/aabmass"><code>@​aabmass</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/379">GoogleCloudPlatform/opentelemetry-operations-java#379</a></li>
<li>Update dependencies by <a href="https://github.com/psx95"><code>@​psx95</code></a> in <a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/381">GoogleCloudPlatform/opentelemetry-operations-java#381</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/compare/v0.32.0...v0.33.0">https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/compare/v0.32.0...v0.33.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/6455156e9d97eb882f9cca020387ad3cdb525b2e"><code>6455156</code></a> Update dependencies (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/381">#381</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/6301056ea20b30b341b8e16b09c6d1dd2cfe1b7b"><code>6301056</code></a> Mention that newer Log4j2 versions do not need additional fields (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/379">#379</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/9c7510b21512c3d1693041d60a1a483b5db51f93"><code>9c7510b</code></a> Update collector image (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/380">#380</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/4181e2d07a15e056458f9c0a06304f5f5b08aa27"><code>4181e2d</code></a> Add otlp metrics export from Google Cloud Run Functions (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/377">#377</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/ff4949ec1a37057cd3bc5db786d95dc420ee58cd"><code>ff4949e</code></a> Add links to quickstart and observability overview to README (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/378">#378</a>)</li>
<li><a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/commit/371d1cde1745311f30704ea54640728c4d48d6de"><code>371d1cd</code></a> Update RELEASING.md (<a href="https://redirect.github.com/GoogleCloudPlatform/opentelemetry-operations-java/issues/375">#375</a>)</li>
<li>See full diff in <a href="https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/compare/v0.32.0...v0.33.0">compare view</a></li>
</ul>
</details>
<br />
