### PR TITLE
CORE-69: Spring Boot 3.4.0 and otel cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,6 @@ project.ext {
     isCiServer = System.getenv().containsKey("CI")
 }
 
-// Spring Boot 3.4.0 pulls in opentelemetry-bom 1.43.0.
-// When upgrading Spring Boot, re-check these versions.
-ext['opentelemetry.version'] = '1.43.0'
-ext['opentelemetry.instrumentation.version'] = '2.9.0' // 2.9.0 targets opentelemetry 1.43.0
-
 // If true, search local repository (~/.m2/repository/) first for dependencies.
 def useMavenLocal = false
 repositories {
@@ -90,7 +85,10 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
     // OpenTelemetry dependencies:
-    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${project.ext['opentelemetry.instrumentation.version']}-alpha")
+    // Spring Boot 3.4.0 pulls in opentelemetry-bom 1.43.0.
+    // We choose opentelemetry-instrumentation-bom-alpha:2.9.0-alpha because otel-instrumentation 2.9.0 targets otel 1.43.0.
+    // When upgrading Spring Boot, re-check these versions.
+    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.9.0-alpha")
     // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     runtimeOnly group: 'org.postgresql', name: 'postgresql'
 
     // Terra libraries
-    implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: '0.1-0c4b377'
+    implementation group: 'org.broadinstitute.dsde.workbench', name: 'sam-client_2.13', version: 'v0.0.329'
     var stairwayVersion= '1.1.15-SNAPSHOT'
     api "bio.terra:stairway-gcp:${stairwayVersion}"
     implementation "bio.terra:stairway-azure:${stairwayVersion}"
@@ -96,7 +96,6 @@ dependencies {
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
     implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
-
     // ... versioned by opentelemetry-instrumentation-bom-alpha
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'com.jfrog.artifactory' version '5.2.5'
     id 'org.sonarqube' version '5.1.0.4882'
     id 'io.spring.dependency-management' version '1.1.6'
-    id 'org.springframework.boot' version '3.3.4'
+    id 'org.springframework.boot' version '3.4.0'
     id 'ru.vyarus.quality' version '5.0.0'
     id 'com.srcclr.gradle' version '3.1.12'
 }
@@ -20,9 +20,10 @@ project.ext {
     isCiServer = System.getenv().containsKey("CI")
 }
 
-// Spring Boot 3.2.3 pulls in opentelemetry-bom 1.31.0.
+// Spring Boot 3.4.0 pulls in opentelemetry-bom 1.43.0.
 // We need >= 1.32.0 so that our HttpServerMetrics can use Meter.setExplicitBucketBoundariesAdvice:
-ext['opentelemetry.version'] = '1.42.1'
+ext['opentelemetry.version'] = '1.43.0'
+ext['opentelemetry.instrumentation.version'] = '2.9.0' // 2.9.0 targets opentelemetry 1.43.0
 
 // If true, search local repository (~/.m2/repository/) first for dependencies.
 def useMavenLocal = false
@@ -51,6 +52,7 @@ dependencies {
 
     // Spring
     implementation group: 'org.springframework.retry', name: 'spring-retry'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jdbc'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
@@ -87,25 +89,21 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-json-classic', version: '0.1.5'
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
-    // OpenTelemetry BOMs (opentelemetry-bom versioned by Spring dependency manager)
-    // If the following versions get updated, be sure to update line 25 for ext['opentelemetry.version']
-    implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.44.1-alpha')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.10.0')
-    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.10.0-alpha')
-    // OpenTelemetry dependencies versioned by BOMs
+    // OpenTelemetry dependencies:
+    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${project.ext['opentelemetry.instrumentation.version']}-alpha")
+    // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
-    implementation 'io.opentelemetry:opentelemetry-sdk'
-    implementation 'io.opentelemetry:opentelemetry-sdk-metrics'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-6.0'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-autoconfigure'
-    implementation 'io.opentelemetry:opentelemetry-exporter-prometheus'
-    implementation 'io.opentelemetry:opentelemetry-api-incubator'
-    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
-    implementation 'org.springframework.boot:spring-boot-autoconfigure'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
+
+    // ... versioned by opentelemetry-instrumentation-bom-alpha
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-autoconfigure'
+    implementation 'io.opentelemetry.semconv:opentelemetry-semconv'
+    implementation 'io.opentelemetry:opentelemetry-api-incubator'
+    implementation 'io.opentelemetry:opentelemetry-exporter-prometheus'
 
     // Google cloud open telemetry exporters
     implementation 'com.google.cloud.opentelemetry:exporter-trace:0.33.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ project.ext {
 }
 
 // Spring Boot 3.4.0 pulls in opentelemetry-bom 1.43.0.
-// We need >= 1.32.0 so that our HttpServerMetrics can use Meter.setExplicitBucketBoundariesAdvice:
+// When upgrading Spring Boot, re-check these versions.
 ext['opentelemetry.version'] = '1.43.0'
 ext['opentelemetry.instrumentation.version'] = '2.9.0' // 2.9.0 targets opentelemetry 1.43.0
 

--- a/src/test/java/bio/terra/common/logging/HumanReadableLoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/HumanReadableLoggingTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.boot.test.web.client.TestRestTemplate;

--- a/src/test/java/bio/terra/common/logging/HumanReadableLoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/HumanReadableLoggingTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 /**
  * A test to verify that the human-readable-logging Spring Profile will disable the configuration of
@@ -32,7 +33,7 @@ class HumanReadableLoggingTest {
 
   @Autowired private TestRestTemplate testRestTemplate;
   // Spy bean to allow us to mock out the RequestIdFilter ID generator.
-  @SpyBean private RequestIdFilter requestIdFilter;
+  @MockitoSpyBean private RequestIdFilter requestIdFilter;
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/bio/terra/common/logging/LoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.boot.test.web.client.TestRestTemplate;

--- a/src/test/java/bio/terra/common/logging/LoggingTest.java
+++ b/src/test/java/bio/terra/common/logging/LoggingTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
@@ -55,7 +56,7 @@ public class LoggingTest {
 
   @Autowired private TestRestTemplate testRestTemplate;
   // Spy bean to allow us to mock out the RequestIdFilter ID generator.
-  @SpyBean private RequestIdFilter requestIdFilter;
+  @MockitoSpyBean private RequestIdFilter requestIdFilter;
 
   @BeforeEach
   public void setUp() throws IOException, ServletException {


### PR DESCRIPTION
* Upgrade to Spring Boot 3.4.0
* Align OpenTelemetry dependencies to the Spring Boot version and to each other
* Remove usages of `@SpyBean`, which is now deprecated
* bonus: update `sam-client` to latest

This PR supersedes #210

References: 
https://docs.spring.io/spring-boot/appendix/dependency-versions/coordinates.html
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes#deprecation-of-mockbean-and-spybean