### PR TITLE
Update actions to current versions to fix build errors

### DIFF
--- a/.github/actions/setup-gradlew/action.yml
+++ b/.github/actions/setup-gradlew/action.yml
@@ -9,13 +9,13 @@ runs:
 
   steps:
   - name: Set up JDK 17
-    uses: actions/setup-java@v3
+    uses: actions/setup-java@v4
     with:
       java-version: '17'
       distribution: 'temurin'
 
   - name: Cache Gradle packages
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: |
         ~/.gradle/caches

--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout current code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: develop
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
       run: ./gradlew build
     - name: Upload Test Reports
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Test Reports
         path: build/reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,19 +26,19 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout current code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initialize Postgres DB
         env:
           PGPASSWORD: postgres
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
       # See https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -52,7 +52,7 @@ jobs:
         run: ./gradlew build --scan
       - name: Upload Test Reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Reports
           path: build/reports


### PR DESCRIPTION
Fix issue where builds are failing now that various github actions have been completely deprecated are are no longer supported. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/