### PR TITLE
TSPS-404 Throw correct exception for Sam user not found

### DIFF
--- a/src/main/java/bio/terra/common/iam/SamUserFactory.java
+++ b/src/main/java/bio/terra/common/iam/SamUserFactory.java
@@ -64,7 +64,7 @@ public class SamUserFactory {
     } catch (final NullPointerException e) {
       throw new UnauthorizedException(e.getMessage(), e);
     } catch (final ApiException e) {
-      if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
+      if (e.getCode() == HttpStatus.NOT_FOUND.value() || e.getCode() == HttpStatus.FORBIDDEN.value()) {
         throw new UnauthorizedException("User not found", e);
       } else {
         throw new InternalServerErrorException(e);

--- a/src/main/java/bio/terra/common/iam/SamUserFactory.java
+++ b/src/main/java/bio/terra/common/iam/SamUserFactory.java
@@ -64,7 +64,8 @@ public class SamUserFactory {
     } catch (final NullPointerException e) {
       throw new UnauthorizedException(e.getMessage(), e);
     } catch (final ApiException e) {
-      if (e.getCode() == HttpStatus.NOT_FOUND.value() || e.getCode() == HttpStatus.FORBIDDEN.value()) {
+      if (e.getCode() == HttpStatus.NOT_FOUND.value()
+          || e.getCode() == HttpStatus.FORBIDDEN.value()) {
         throw new UnauthorizedException("User not found", e);
       } else {
         throw new InternalServerErrorException(e);

--- a/src/test/java/bio/terra/common/iam/SamUserFactoryTest.java
+++ b/src/test/java/bio/terra/common/iam/SamUserFactoryTest.java
@@ -72,9 +72,9 @@ public class SamUserFactoryTest {
     UsersApi usersApi = mock(UsersApi.class);
     when(factory.createUsersApi(SAM_USER.getBearerToken(), SAM_BASE_PATH)).thenReturn(usersApi);
     when(usersApi.getSamUserSelf())
-            .thenThrow(new ApiException(HttpStatus.FORBIDDEN.value(), "not found"));
+        .thenThrow(new ApiException(HttpStatus.FORBIDDEN.value(), "not found"));
 
     assertThrows(
-            UnauthorizedException.class, () -> factory.from(SAM_USER.getBearerToken(), SAM_BASE_PATH));
+        UnauthorizedException.class, () -> factory.from(SAM_USER.getBearerToken(), SAM_BASE_PATH));
   }
 }

--- a/src/test/java/bio/terra/common/iam/SamUserFactoryTest.java
+++ b/src/test/java/bio/terra/common/iam/SamUserFactoryTest.java
@@ -65,4 +65,16 @@ public class SamUserFactoryTest {
     assertThrows(
         UnauthorizedException.class, () -> factory.from(SAM_USER.getBearerToken(), SAM_BASE_PATH));
   }
+
+  @Test
+  public void forbiddenUser() throws ApiException {
+    SamUserFactory factory = spy(new SamUserFactory(new BearerTokenFactory(), Optional.empty()));
+    UsersApi usersApi = mock(UsersApi.class);
+    when(factory.createUsersApi(SAM_USER.getBearerToken(), SAM_BASE_PATH)).thenReturn(usersApi);
+    when(usersApi.getSamUserSelf())
+            .thenThrow(new ApiException(HttpStatus.FORBIDDEN.value(), "not found"));
+
+    assertThrows(
+            UnauthorizedException.class, () -> factory.from(SAM_USER.getBearerToken(), SAM_BASE_PATH));
+  }
 }


### PR DESCRIPTION
Teaspoons [uses](https://github.com/DataBiosphere/terra-scientific-pipelines-service/blob/main/service/src/main/java/bio/terra/pipelines/app/controller/PipelinesApiController.java#L46) TCL's SamUserFactory to check that the user is registered in Sam.

However, if a user is not registered in Sam/Terra, TCL is currently throwing an InternalServerErrorException that results in a 500 response, with the error message stating that the user was not found in Sam and an error code of 403 (FORBIDDEN). That's because TCL expects Sam to return a 404 (NOT_FOUND), so it doesn't properly handle the 403 [that Sam returns in this case ](https://github.com/broadinstitute/sam/blob/develop/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala#L241).

This PR updates the logic so that TCL treats both a 404 and a 403 as "User not found".

Teaspoons Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-404 