### PR TITLE
CORE-69: bump k8s client-java lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,9 @@ dependencies {
     annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
 
     // Misc. Services
-    implementation group: 'io.kubernetes', name: 'client-java', version: '22.0.0-legacy'
+    //  note that k8s client-java -legacy and non-legacy libraries are not interchangeable
+    //  see https://github.com/kubernetes-client/java?tab=readme-ov-file#release
+    implementation group: 'io.kubernetes', name: 'client-java', version: '23.0.0'
     constraints {
         implementation('org.bouncycastle:bcprov-jdk18on:1.80') {
             because 'https://broadworkbench.atlassian.net/browse/DCJ-275'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-69

supersedes #226

terra-common-lib had used the non-legacy versions of k8s client-java up until #220. This PR bumps client-java from the 22.x version to 23.x _and_ switches back to the non-legacy version.

The 23.x -legacy version shows compile problems in #226.