### PR TITLE
CORE-376: disable default otlp trace exports

### DIFF
--- a/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
+++ b/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
@@ -33,8 +33,9 @@ public class OpenTelemetryConfig {
       // the default exporter is the OTLP exporter, which we don't use and outputs errors like:
       // ERROR [OkHttp http://localhost:4318/...] i.o.e.internal.http.HttpExporter: Failed to export
       // metrics. The request could not be executed. Full error message: Failed to connect to
-      // localhost/[0:0:0:0:0:0:0:1]:4318
-      customizer.addPropertiesCustomizer((unused) -> Map.of("otel.metrics.exporter", "none"));
+      // localhost/[0:0:0:0:0:0:0:1]:4318.
+      // The error message may also be "Failed to export spans"
+      customizer.addPropertiesCustomizer((unused) -> Map.of("otel.metrics.exporter", "none", "otel.traces.exporter", "none"));
 
       customizer.addMeterProviderCustomizer(
           (builder, unused) -> {

--- a/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
+++ b/src/main/java/bio/terra/common/opentelemetry/OpenTelemetryConfig.java
@@ -35,7 +35,8 @@ public class OpenTelemetryConfig {
       // metrics. The request could not be executed. Full error message: Failed to connect to
       // localhost/[0:0:0:0:0:0:0:1]:4318.
       // The error message may also be "Failed to export spans"
-      customizer.addPropertiesCustomizer((unused) -> Map.of("otel.metrics.exporter", "none", "otel.traces.exporter", "none"));
+      customizer.addPropertiesCustomizer(
+          (unused) -> Map.of("otel.metrics.exporter", "none", "otel.traces.exporter", "none"));
 
       customizer.addMeterProviderCustomizer(
           (builder, unused) -> {


### PR DESCRIPTION
We were attempting to export otel spans twice:
* once successfully as configured by terra-common-lib, exporting to GCP;
* a second time unsuccessfully as auto-configured by Spring, attempting to export to a local otel collector. This second time was continually logging a "failed to export spans" error.

This PR turns off the auto-configured otel export. This quells the error. Spans are still successfully exported - once - to GCP.

Inspired by https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/200

Tested by:
* running BPM locally and seeing the "Failed to export spans" error
* publishing this PR to mavenLocal
* modifying BPM to pull the mavenLocal version
* running BPM locally again; seeing the "Failed to export spans" error go away, and validating I still see spans in GCP Trace Explorer

