### PR TITLE
[DT-2062] Sync updates to data team schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,24 @@
 version: 2
 updates:
-  - package-ecosystem: "gradle"
+  - package-ecosystem: gradle
     directory: "/"
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 10
     groups:
-      minor-patch-dependencies:
+      gradle-dependencies:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
+      gradle-patch-updates:
+        update-types:
           - "patch"
     schedule:
-      interval: "monthly"
-      time: "06:00"
-      timezone: "America/New_York"
+      interval: cron
+      cronjob: "0 0 1,15 * *"
     target-branch: "develop"
-    reviewers:
-      - "@DataBiosphere/platform-foundation-codeowners"
     labels:
       - "dependency"
       - "gradle"
     commit-message:
-      prefix: "[PF-2983]"
+      prefix: "[DT-400-gradle]"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2062

### Summary

Updates the Dependabot configuration to match the other Data Team repositories.