### PR TITLE
[CORE-69] Update opentelemetry version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,12 +87,7 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
     // OpenTelemetry dependencies:
-    // Spring Boot 3.4.3 still pulls in opentelemetry-bom 1.43.0.
-    // Note that opentelemetry-instrumentation-bom-alpha:2.12.0-alpha targets opentelemetry 1.46.0 which
-    // is still compatible, but opentelemetry-instrumentation-bom-alpha:2.13.3-alpha targets opentelemetry 1.47.0
-    // which is no longer compatible and we will need to wait until spring boot 3.5.x to be able to update that dependency further
-    // When upgrading Spring Boot, re-check these versions.
-//    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.12.0-alpha")
+    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.14.0-alpha")
     // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
     // OpenTelemetry dependencies:
-    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.19.0-alpha")
+    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.18.1-alpha")
     // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
     // OpenTelemetry dependencies:
-    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.14.0-alpha")
+    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.19.0-alpha")
     // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
     // OpenTelemetry dependencies:
-    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.18.1-alpha")
+    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.14.0-alpha")
     // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
 
     // OpenTelemetry dependencies:
-    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.14.0-alpha")
+    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.15.0-alpha")
     // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     // is still compatible, but opentelemetry-instrumentation-bom-alpha:2.13.3-alpha targets opentelemetry 1.47.0
     // which is no longer compatible and we will need to wait until spring boot 3.5.x to be able to update that dependency further
     // When upgrading Spring Boot, re-check these versions.
-    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.12.0-alpha")
+//    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.12.0-alpha")
     // ... versioned by Spring Boot
     api 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry:opentelemetry-exporter-logging'


### PR DESCRIPTION
Updating `terra-common-lib` downstream is [causing](https://github.com/broadinstitute/sam/pull/1715) [failures](https://github.com/broadinstitute/rawls/pull/3469) (note that the first linked PR is currently passing due to reverting the TCL upgrade), apparently because in the imported version of `io.opentelemetry`, `ResourceAttributes` is deprecated.  Investigating the origin of opentelemetry in TCL revealed a note about version incompatibilities with spring boot < 3.5.  But TCL's spring boot version is not 3.5, so opentelemetry can now be updated.  This PR updates the specified opentelemetry version, but I'm not sure if that's the right way to go or if we actually want to NOT specify it since it should be pulled in through spring boot.  My attempt to remove the line in question resulted in failures, as did attempts to update to versions later than 2.14.0