### PR TITLE
[DT-1459] TCL: Migrate to GAR from Artifactory

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -1,5 +1,7 @@
 name: development version bump
 on:
+  pull_request:
+    branches: [ develop ]
   push:
     branches: [ develop ]
     paths-ignore: [ '**.md' ]
@@ -28,7 +30,7 @@ jobs:
     - name: Checkout current code
       uses: actions/checkout@v4
       with:
-        ref: develop
+        ref: ${{ github.head_ref || '' }}
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
 
     - name: Skip version bump merges

--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   publish_snapshot:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -63,10 +66,16 @@ jobs:
         VERSION_LINE_MATCH: "^\\s*gradle.ext.tclVersion\\s*=\\s*'.*'"
         VERSION_SUFFIX: SNAPSHOT
 
-    - name: "Publish to Artifactory"
-      if: steps.bump-skip.outputs.is-bump == 'no'
-      run: ./gradlew artifactoryPublish
+    - name: "Authenticate to GCP"
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: access_token
+        workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+        service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
+
+    - name: "Publish client to GAR"
+      run: ./gradlew publish
       env:
-        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-        ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+        GOOGLE_CLOUD_PROJECT: dsp-artifact-registry
+        GAR_LOCATION: us-central1
+        GAR_REPOSITORY_ID: libs-snapshot-standard

--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -69,7 +69,7 @@ jobs:
         VERSION_SUFFIX: SNAPSHOT
 
     - name: "Authenticate to GCP"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         token_format: access_token
         workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # terra-common-lib
 ## Publishing 
-MC Terra components use JFrog Artifactory to publish libraries to a central Maven [repository](https://broadinstitute.jfrog.io/ui/packages).
+MC Terra components use Google Artifact Registry to publish libraries to a central Maven [repository](https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-snapshot-standard).
 The library version number is the `version` in [build.gradle](build.gradle). We use [github actions](/.github/workflows) to bumping version and publish to repository.
 
 The publishing procedure is:
-1. After PR is merged to develop branch: github action automatically bumped the minor `version` in [build.gradle](build.gradle) then publish to [lib-snapshot-local](https://broadinstitute.jfrog.io/ui/repos/tree/General/libs-snapshot-local)
-2. After release is created(usually a manual step): github action automatically bumped the minor `version` in [build.gradle](build.gradle) then publish to [lib-snapshot-release](https://broadinstitute.jfrog.io/ui/repos/tree/General/libs-release-local).
+1. After PR is merged to develop branch: github action automatically bumped the minor `version` in [build.gradle](build.gradle) then publish to [lib-snapshot-standard](https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-snapshot-standard)
+2. After release is created(usually a manual step): github action automatically bumped the minor `version` in [build.gradle](build.gradle) then publish to [lib-release-standard](https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-release-standard?inv=1&invt=Abymcg&project=dsp-artifact-registry).
 3. To bump major version, we need manually update `version` in [build.gradle](build.gradle) value first then create the release.
  
 ## Development 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
     id 'com.diffplug.spotless' version '7.2.1'
     id 'com.github.ben-manes.versions' version '0.52.0'
-    id 'com.jfrog.artifactory' version '5.2.5'
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.1.5'
     id 'org.sonarqube' version '6.3.1.5724'
     id 'io.spring.dependency-management' version '1.1.7'
     // when updating spring boot version, check whether any changes are needed in the opentelemetry-bom version below

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,17 +1,10 @@
-def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-snapshot-local'
-def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
-def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
+def garProjectId = System.getenv("GOOGLE_CLOUD_PROJECT")
+def garLocation = System.getenv("GAR_LOCATION")
+def garRepoId = System.getenv("GAR_REPOSITORY_ID")
 
 java {
     // Builds sources into the published package as part of the 'assemble' task.
     withSourcesJar()
-}
-
-gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.hasTask(artifactoryPublish) &&
-            (artifactory_username == null || artifactory_password == null)) {
-        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
-    }
 }
 
 // Publish jar file to a Maven module/artifact using the maven-publish plugin.
@@ -24,21 +17,9 @@ publishing {
             from components.java
         }
     }
-}
-
-// Upload Maven artifacts to Artifactory using the Artifactory plugin.
-artifactory {
-    publish {
-        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-        repository {
-            repoKey = "${artifactory_repo_key}"
-            username = "${artifactory_username}"
-            password = "${artifactory_password}"
-        }
-        defaults {
-            publications('terraCommonLib')
-            publishArtifacts = true
-            publishPom = true
+    repositories {
+        maven {
+            url = uri("artifactregistry://${garLocation}-maven.pkg.dev/${garProjectId}/${garRepoId}")
         }
     }
 }


### PR DESCRIPTION
__Jira ticket__:https://broadworkbench.atlassian.net/browse/DC-1459

## Addresses
The plan to decommission jfrog: https://docs.google.com/document/d/1_x6twTJg40H5suStbN_2MRzwU6rBDEMQj5aAMiWIgb4/edit?usp=sharing

## Summary of changes
Publish to GAR instead of jfrog
Update README

## Testing Strategy
See action for successful publishing run
See [GAR](https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-snapshot-standard) for successfully added artifact