### PR TITLE
[DT-1459] Migrate from jfrog to GAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 
 ### Jenv directory-local version setting
 .java-version
+
+# Credentials files
+**/gha-creds-*.json


### PR DESCRIPTION
## Summary
Now that the SA is added to terraform we need to add add gha cred to gitignore
See comment: https://github.com/broadinstitute/terraform-ap-deployments/pull/1978/files 