### PR TITLE
[DC-1799] Dependabot updates not grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,12 @@ updates:
     directory: "/"
     open-pull-requests-limit: 10
     groups:
-      gradle-dependencies:
+      minor-patch-dependencies:
         patterns:
           - "*"
         update-types:
-          - "major"
-          - "minor"
-      gradle-patch-updates:
-        update-types:
           - "patch"
+          - "minor"
     schedule:
       interval: cron
       cronjob: "0 0 1,15 * *"


### PR DESCRIPTION
## What
https://broadworkbench.atlassian.net/browse/DC-1799
Group minor and patch updates together. 

## Why
Improve efficiency of review for dependabot reviews