### PR TITLE
TSPS-941 override spring boot's netty version for CVE-2026-42587

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ project.ext {
     isCiServer = System.getenv().containsKey("CI")
 }
 
+// Override Spring Boot's managed Netty version to stay aligned with stairway-azure.
+ext['netty.version'] = '4.2.13.Final'
+
 // If true, search local repository (~/.m2/repository/) first for dependencies.
 def useMavenLocal = false
 repositories {


### PR DESCRIPTION
Not gonna lie, i mostly used the robots for this.  I dont think there is a spring boot version that uses this late of a version for netty so AFAIK this is one of a few bad options available.