### PR TITLE
[TSPS-984] Update netty version to 4.2.15.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ project.ext {
 }
 
 // Override Spring Boot's managed Netty version to stay aligned with stairway-azure.
-ext['netty.version'] = '4.2.13.Final'
+// Upgrading to 4.2.15.Final fixes CVE-2026-45416.
+ext['netty.version'] = '4.2.15.Final'
 
 // If true, search local repository (~/.m2/repository/) first for dependencies.
 def useMavenLocal = false


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/TSPS-984

Fixes https://nvd.nist.gov/vuln/detail/CVE-2026-45416. This fix is also needed in terra-scientific-pipeline-service as it imports TCL.